### PR TITLE
Don't validate CircleCI config

### DIFF
--- a/script/src/validate-monorepo/validation/index.ts
+++ b/script/src/validate-monorepo/validation/index.ts
@@ -1,5 +1,8 @@
 import { join } from 'node:path';
-import { getRustPackageIds, getWorkspacePackageInfo } from '@votingworks/monorepo-utils';
+import {
+  getRustPackageIds,
+  getWorkspacePackageInfo,
+} from '@votingworks/monorepo-utils';
 import * as circleci from './circleci';
 import * as pkgs from './packages';
 import * as tsconfig from './tsconfig';
@@ -31,5 +34,6 @@ export async function* validateMonorepo(): AsyncGenerator<ValidationIssue> {
     workspacePackages,
   });
   yield* tsconfig.checkConfig(workspacePackages);
-  yield* circleci.checkConfig(workspacePackages, rustPackageIds);
+  // TODO re-enable once we want to run tests
+  // yield* circleci.checkConfig(workspacePackages, rustPackageIds);
 }


### PR DESCRIPTION
We aren't using the tests for now, so it's ok to have an outdated CircleCI config. We'll want to revert this change once we use CI again.