### PR TITLE
Initial Implementation of Multi-Node data syncing

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,20 @@
+const shared = require('../jest.config.shared');
+
+/**
+ * @type {import('@jest/types').Config.InitialOptions}
+ */
+module.exports = {
+  ...shared,
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
+  coverageThreshold: {
+    global: {
+      lines: 0,
+      branches: 0,
+    },
+  },
+  prettierPath: null,
+  transformIgnorePatterns: [
+    '[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|cjs|ts|tsx)$',
+  ],
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,9 +22,9 @@
     "pre-commit": "lint-staged",
     "start": "node ./build/index.js",
     "test": "is-ci test:ci test:watch",
-    "test:ci": "TZ=America/Anchorage vitest run --coverage",
-    "test:coverage": "TZ=America/Anchorage vitest --coverage",
-    "test:watch": "TZ=America/Anchorage vitest",
+    "test:ci": "TZ=America/Anchorage jest run --coverage",
+    "test:coverage": "TZ=America/Anchorage jest --coverage",
+    "test:watch": "TZ=America/Anchorage jest --watch",
     "type-check": "tsc --build"
   },
   "dependencies": {
@@ -58,9 +58,11 @@
   "devDependencies": {
     "@jest/globals": "^29.6.2",
     "@jest/types": "^29.6.1",
+    "@testing-library/react": "^15.0.7",
     "@types/debug": "4.1.8",
     "@types/express": "4.17.14",
     "@types/fs-extra": "11.0.1",
+    "@types/jest": "^29.5.3",
     "@types/node": "20.16.0",
     "@types/react": "18.3.3",
     "@types/styled-components": "^5.1.26",
@@ -70,10 +72,16 @@
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "2.2.0",
+    "jest": "^29.6.2",
+    "jest-environment-jsdom": "^29.6.2",
+    "jest-junit": "^16.0.0",
+    "jest-styled-components": "^7.1.1",
+    "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "11.0.0",
     "nodemon": "^3.1.7",
     "sort-package-json": "^1.50.0",
-    "tmp": "^0.2.1"
+    "tmp": "^0.2.1",
+    "ts-jest": "29.1.1"
   },
   "engines": {
     "node": ">= 12"

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -1,0 +1,18 @@
+CREATE TABLE voters (
+    voter_id TEXT PRIMARY KEY,
+    voter_data TEXT not null
+);
+
+CREATE TABLE elections (
+    election_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    election_data TEXT not null
+);
+
+CREATE TABLE event_log (
+    event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    machine_id TEXT,
+    timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    event_type TEXT, -- e.g., "check_in", "undo_check_in"
+    voter_id TEXT, -- voter_id of the voter involved in the event, if any
+    event_data TEXT not null -- JSON data for additional details associated with the event (id type used for check in, etc.)
+);

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -4,15 +4,16 @@ CREATE TABLE voters (
 );
 
 CREATE TABLE elections (
-    election_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    election_id TEXT PRIMARY KEY,
     election_data TEXT not null
 );
 
 CREATE TABLE event_log (
-    event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id INTEGER,
     machine_id TEXT,
     timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     event_type TEXT, -- e.g., "check_in", "undo_check_in"
     voter_id TEXT, -- voter_id of the voter involved in the event, if any
-    event_data TEXT not null -- JSON data for additional details associated with the event (id type used for check in, etc.)
+    event_data TEXT not null, -- JSON data for additional details associated with the event (id type used for check in, etc.)
+    PRIMARY KEY (event_id, machine_id)
 );

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -30,6 +30,9 @@ import {
   DeviceStatuses,
   Election,
   ElectionSchema,
+  MachineInformation,
+  PollbookConnectionStatus,
+  PollbookEvent,
   PollbookPackage,
   PollBookService,
   Voter,
@@ -198,40 +201,77 @@ async function setupMachineNetworking({
   process.nextTick(async () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     for await (const _ of setInterval(NETWORK_POLLING_INTERVAL)) {
+      const currentElection = workspace.store.getElection();
       debug('Polling network for new machines');
       const services = await AvahiService.discoverHttpServices();
+      const previouslyConnected = workspace.store.getPollbookServicesByName();
+      // If there are any services that were previously connected that no longer show up in avahi
+      // Mark them as shut down
+      for (const [name, service] of Object.entries(previouslyConnected)) {
+        if (!services.some((s) => s.name === name)) {
+          debug(
+            'Marking %s as shut down as it is no longer published on Avahi',
+            name
+          );
+          service.lastSeen = new Date();
+          workspace.store.setPollbookServiceForName(name, {
+            ...service,
+            apiClient: undefined,
+            status: PollbookConnectionStatus.ShutDown,
+          });
+        }
+      }
       for (const { name, host, port } of services) {
         if (name === currentNodeServiceName) {
           // current machine, do not need to connect
           continue;
         }
-        const currentPollbookService =
-          workspace.store.getPollbookServiceForName(name);
-        const apiClient = currentPollbookService
-          ? currentPollbookService.apiClient
-          : createApiClientForAddress(`http://${host}:${port}`);
+        const currentPollbookService = previouslyConnected[name];
+        const apiClient =
+          currentPollbookService && currentPollbookService.apiClient
+            ? currentPollbookService.apiClient
+            : createApiClientForAddress(`http://${host}:${port}`);
 
         try {
-          const retrievedMachineId = await apiClient.getMachineId();
-          if (currentPollbookService) {
-            currentPollbookService.lastSeen = new Date();
-            workspace.store.setPollbookServiceForName(
-              name,
-              currentPollbookService
-            );
-          } else {
-            debug(
-              'Discovered new pollbook with machineId %s on the network',
-              retrievedMachineId
-            );
+          const machineInformation = await apiClient.getMachineInformation();
+          if (
+            !currentElection ||
+            currentElection.id !== machineInformation.configuredElectionId
+          ) {
+            // Only connect if the two machines are configured for the same election.
             workspace.store.setPollbookServiceForName(name, {
-              machineId: retrievedMachineId,
+              machineId: machineInformation.machineId,
               apiClient,
               lastSeen: new Date(),
+              status: PollbookConnectionStatus.WrongElection,
             });
+            continue;
           }
+          if (
+            !currentPollbookService ||
+            currentPollbookService.status !== PollbookConnectionStatus.Connected
+          ) {
+            debug(
+              'Establishing connection with a new pollbook service with machineId %s',
+              machineInformation.machineId
+            );
+          }
+          // Sync events from this pollbook service.
+          const knownMachines = workspace.store.getKnownMachinesWithEventIds();
+          const events = await apiClient.getEvents({
+            knownMachines,
+          });
+          workspace.store.saveEvents(events);
+
+          // Mark as connected so future events automatically sync.
+          workspace.store.setPollbookServiceForName(name, {
+            machineId: machineInformation.machineId,
+            apiClient,
+            lastSeen: new Date(),
+            status: PollbookConnectionStatus.Connected,
+          });
         } catch (error) {
-          debug(`Failed to get machineId from ${name}: ${error}`);
+          debug(`Failed to establish connection from ${name}: ${error}`);
         }
       }
       // Clean up stale machines
@@ -351,7 +391,7 @@ function buildApi(context: AppContext) {
     },
 
     undoVoterCheckIn(input: { voterId: string }): void {
-      store.recordUndoVoterCheckIn(input.voterId)
+      store.recordUndoVoterCheckIn(input.voterId);
     },
 
     getCheckInCounts(): { thisMachine: number; allMachines: number } {
@@ -361,8 +401,22 @@ function buildApi(context: AppContext) {
       };
     },
 
-    getMachineId(): string {
-      return machineId;
+    getMachineInformation(): MachineInformation {
+      const election = store.getElection();
+      return {
+        machineId,
+        configuredElectionId: election ? election.id : undefined,
+      };
+    },
+
+    receiveEvent(input: { pollbookEvent: PollbookEvent }): boolean {
+      return store.saveEvent(input.pollbookEvent);
+    },
+
+    getEvents(input: {
+      knownMachines: Record<string, number>;
+    }): PollbookEvent[] {
+      return store.getNewEvents(input.knownMachines);
     },
   });
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -34,7 +34,6 @@ import {
   PollbookConnectionStatus,
   PollbookEvent,
   PollbookPackage,
-  PollBookService,
   Voter,
   VoterIdentificationMethod,
   VoterSearchParams,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -31,7 +31,6 @@ function main(): Promise<number> {
     );
   }
   const workspacePath = resolve(WORKSPACE);
-  const workspace = createWorkspace(workspacePath, baseLogger);
 
   const auth = new DippedSmartCardAuth({
     card:
@@ -44,17 +43,19 @@ function main(): Promise<number> {
     },
     logger: baseLogger,
   });
+  const machineId = process.env.VX_MACHINE_ID || 'dev';
 
   const logger = Logger.from(baseLogger, () => Promise.resolve('system'));
   const usbDrive = detectUsbDrive(logger);
   const printer = detectPrinter(logger);
+  const workspace = createWorkspace(workspacePath, baseLogger, machineId);
 
   server.start({
     workspace,
     auth,
     usbDrive,
     printer,
-    machineId: process.env.VX_MACHINE_ID || 'dev',
+    machineId,
   });
   backupWorker.start({ workspace, usbDrive });
 

--- a/backend/src/store.test.ts
+++ b/backend/src/store.test.ts
@@ -1,0 +1,95 @@
+import { assert } from '@votingworks/basics';
+import { Store } from './store';
+import { EventType, VoterCheckInEvent } from './types';
+
+const myMachineId = 'machine-1';
+const otherMachineId = 'machine-2';
+
+function createTestStore(): Store {
+  return Store.memoryStore(myMachineId);
+}
+
+function createVoterCheckInEvent(
+  eventId: number,
+  machineId: string,
+  voterId: string
+): VoterCheckInEvent {
+  return {
+    type: EventType.VoterCheckIn,
+    eventId,
+    machineId,
+    timestamp: new Date().toISOString(),
+    voterId,
+    checkInData: {
+      timestamp: new Date().toISOString(),
+      identificationMethod: {
+        type: 'photoId',
+        state: 'nh',
+      },
+      machineId,
+    },
+  };
+}
+
+test('getNewEvents returns events for unknown machines', () => {
+  const store = createTestStore();
+  const event1 = createVoterCheckInEvent(1, myMachineId, 'voter-1');
+  const event2 = createVoterCheckInEvent(2, otherMachineId, 'voter-2');
+
+  store.saveEvent(event1);
+  store.saveEvent(event2);
+
+  const knownMachines: Record<string, number> = {};
+  const events = store.getNewEvents(knownMachines);
+
+  assert(events.length === 2);
+  expect(events).toEqual([event1, event2]);
+});
+
+test('getNewEvents returns events for known machines with new events', () => {
+  const store = createTestStore();
+  const event1 = createVoterCheckInEvent(1, myMachineId, 'voter-1');
+  const event2 = createVoterCheckInEvent(2, otherMachineId, 'voter-2');
+  const event3 = createVoterCheckInEvent(1, myMachineId, 'voter-3');
+
+  store.saveEvent(event1);
+  store.saveEvent(event2);
+  store.saveEvent(event3);
+
+  const knownMachines: Record<string, number> = {
+    [myMachineId]: 1,
+    [otherMachineId]: 1,
+  };
+  const events = store.getNewEvents(knownMachines);
+
+  assert(events.length === 1);
+  expect(events).toEqual([event2]);
+});
+
+test('getNewEvents returns no events for known machines and unknown machines', () => {
+  const store = createTestStore();
+  const event1 = createVoterCheckInEvent(1, myMachineId, 'voter-1');
+  const event2 = createVoterCheckInEvent(2, myMachineId, 'voter-2');
+  const event3 = createVoterCheckInEvent(3, myMachineId, 'voter-3');
+  const event4 = createVoterCheckInEvent(4, myMachineId, 'voter-4');
+  const event5 = createVoterCheckInEvent(5, myMachineId, 'voter-5');
+  const event6 = createVoterCheckInEvent(1, otherMachineId, 'voter-6');
+  const event7 = createVoterCheckInEvent(2, otherMachineId, 'voter-7');
+
+  store.saveEvent(event1);
+  store.saveEvent(event2);
+  store.saveEvent(event3);
+  store.saveEvent(event4);
+  store.saveEvent(event5);
+  store.saveEvent(event6);
+  store.saveEvent(event7);
+
+  const knownMachines: Record<string, number> = {
+    [myMachineId]: 3,
+    'not-a-machine': 1,
+  };
+  const events = store.getNewEvents(knownMachines);
+
+  assert(events.length === 4);
+  expect(events).toEqual([event6, event7, event4, event5]);
+});

--- a/backend/src/store.ts
+++ b/backend/src/store.ts
@@ -4,12 +4,17 @@ import { join } from 'node:path';
 // import { v4 as uuid } from 'uuid';
 import { BaseLogger } from '@votingworks/logging';
 import { assert, find, groupBy } from '@votingworks/basics';
+import { safeParseJson } from '@votingworks/types';
 import { rootDebug } from './debug';
 import {
   Election,
+  ElectionSchema,
+  EventType,
   PollBookService,
   Voter,
+  VoterCheckInSchema,
   VoterIdentificationMethod,
+  VoterSchema,
   VoterSearchParams,
 } from './types';
 import { MACHINE_DISCONNECTED_TIMEOUT } from './globals';
@@ -51,13 +56,107 @@ export class Store {
     return new Store(DbClient.memoryClient(SchemaPath));
   }
 
+  private applyEventsToVoters(voters: Voter[]): Voter[] {
+    const rows = this.client.all(
+      `
+      select voter_id, event_type, event_data
+      from event_log
+      where event_type = ?
+      order by timestamp
+      `,
+      EventType.VoterCheckIn
+    ) as Array<{
+      voter_id: string;
+      event_type: EventType;
+      event_data: string;
+    }>;
+    if (!rows) {
+      return voters;
+    }
+    for (const row of rows) {
+      const voter = find(voters, (v) => v.voterId === row.voter_id);
+      if (!voter) {
+        continue;
+      }
+      voter.checkIn = safeParseJson(
+        row.event_data,
+        VoterCheckInSchema
+      ).unsafeUnwrap();
+    }
+    return voters;
+  }
+
+  private getVoters(): Voter[] | undefined {
+    if (!data.voters) {
+      // Load the voters from the database if they are not in memory.
+      const rows = this.client.all(
+        `
+          select voter_data
+          from voters
+        `
+      ) as Array<{ voter_data: string }>;
+      if (!rows) {
+        return undefined;
+      }
+      data.voters = rows.map((row) =>
+        safeParseJson(row.voter_data, VoterSchema).unsafeUnwrap()
+      );
+    }
+    return this.applyEventsToVoters(data.voters);
+  }
+
   getElection(): Election | undefined {
+    if (!data.election) {
+      // Load the election from the database if its not in memory.
+      const row = this.client.one(
+        `
+          select election_data
+          from elections
+          order by rowid desc
+          limit 1
+        `
+      ) as { election_data: string };
+      if (!row) {
+        return undefined;
+      }
+      const election: Election = safeParseJson(
+        row.election_data,
+        ElectionSchema
+      ).unsafeUnwrap();
+      data.election = election;
+    }
     return data.election;
   }
 
   setElectionAndVoters(election: Election, voters: Voter[]): void {
     data.election = election;
     data.voters = voters;
+    this.client.transaction(() => {
+      this.client.run(
+        `
+          insert into elections (
+            election_data
+          ) values (
+            ?
+          )
+        `,
+        JSON.stringify(election)
+      );
+      for (const voter of voters) {
+        this.client.run(
+          `
+            insert into voters (
+              voter_id,
+              voter_data
+            ) values (
+              ?, ?
+            )
+          `,
+          voter.voterId,
+          JSON.stringify(voter)
+        );
+      }
+    });
   }
 
   deleteElectionAndVoters(): void {
@@ -66,16 +165,18 @@ export class Store {
   }
 
   groupVotersAlphabeticallyByLastName(): Array<Voter[]> {
-    assert(data.voters);
-    return groupBy(data.voters, (v) => v.lastName[0].toUpperCase()).map(
+    const voters = this.getVoters();
+    assert(voters);
+    return groupBy(voters, (v) => v.lastName[0].toUpperCase()).map(
       ([, voterGroup]) => voterGroup
     );
   }
 
   searchVoters(searchParams: VoterSearchParams): Voter[] | number {
-    assert(data.voters);
+    const voters = this.getVoters();
+    assert(voters);
     const MAX_VOTER_SEARCH_RESULTS = 20;
-    const matchingVoters = data.voters.filter(
+    const matchingVoters = voters.filter(
       (voter) =>
         voter.lastName
           .toUpperCase()
@@ -101,13 +202,21 @@ export class Store {
     machineId: string;
     timestamp: Date;
   }): { voter: Voter; count: number } {
-    assert(data.voters);
-    const voter = find(data.voters, (v) => v.voterId === voterId);
+    const voters = this.getVoters();
+    assert(voters);
+    const voter = find(voters, (v) => v.voterId === voterId);
     voter.checkIn = {
       timestamp: timestamp.toISOString(),
       identificationMethod,
       machineId,
     };
+    this.client.run(
+      'INSERT INTO event_log (machine_id, voter_id, event_type, event_data) VALUES (?, ?, ?, ?)',
+      machineId,
+      voterId,
+      EventType.VoterCheckIn,
+      JSON.stringify(voter.checkIn)
+    );
     return { voter, count: this.getCheckInCount() };
   }
 
@@ -115,12 +224,14 @@ export class Store {
     assert(data.voters);
     const voter = find(data.voters, (v) => v.voterId === voterId);
     voter.checkIn = undefined;
+    // TODO CARO implement
     return voter;
   }
 
   getCheckInCount(machineId?: string): number {
-    assert(data.voters);
-    return data.voters.filter(
+    const voters = this.getVoters();
+    assert(voters);
+    return voters.filter(
       (voter) =>
         voter.checkIn && (!machineId || voter.checkIn.machineId === machineId)
     ).length;

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -143,6 +143,24 @@ export const VoterSchema: z.ZodSchema<Voter> = z.object({
   checkIn: VoterCheckInSchema.optional(),
 });
 
+export interface MachineInformation {
+  machineId: string;
+  configuredElectionId?: string;
+}
+
+export interface PollbookEvent {
+  type: EventType;
+  eventId: number;
+  machineId: string;
+  timestamp: string;
+}
+
+export interface VoterCheckInEvent extends PollbookEvent {
+  type: EventType.VoterCheckIn;
+  voterId: string;
+  checkInData: VoterCheckIn;
+}
+
 export interface VoterSearchParams {
   lastName: string;
   firstName: string;
@@ -154,9 +172,16 @@ export interface PollbookPackage {
 }
 
 export interface PollBookService {
-  apiClient: grout.Client<Api>;
+  apiClient?: grout.Client<Api>;
   machineId: string;
+  lastEventIdReceived?: string;
   lastSeen: Date;
+  status: PollbookConnectionStatus;
+}
+
+export interface ConnectedPollbookService extends PollBookService {
+  status: PollbookConnectionStatus.Connected;
+  apiClient: grout.Client<Api>;
 }
 
 export interface NetworkStatus {
@@ -175,4 +200,11 @@ export interface DeviceStatuses {
 export enum EventType {
   VoterCheckIn = 'VoterCheckIn',
   UndoVoterCheckIn = 'UndoVoterCheckIn',
+}
+
+export enum PollbookConnectionStatus {
+  Connected = 'Connected',
+  ShutDown = 'ShutDown',
+  LostConnection = 'LostConnection',
+  WrongElection = 'WrongElection',
 }

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -161,6 +161,11 @@ export interface VoterCheckInEvent extends PollbookEvent {
   checkInData: VoterCheckIn;
 }
 
+export interface UndoVoterCheckInEvent extends PollbookEvent {
+  type: EventType.UndoVoterCheckIn;
+  voterId: string;
+}
+
 export interface VoterSearchParams {
   lastName: string;
   firstName: string;
@@ -207,4 +212,13 @@ export enum PollbookConnectionStatus {
   ShutDown = 'ShutDown',
   LostConnection = 'LostConnection',
   WrongElection = 'WrongElection',
+}
+
+export interface EventDbRow {
+  event_id: number;
+  machine_id: string;
+  voter_id: string;
+  event_type: EventType;
+  timestamp: string;
+  event_data: string;
 }

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -55,6 +55,28 @@ export interface VoterCheckIn {
   machineId: string;
 }
 
+export const VoterCheckInSchema: z.ZodSchema<VoterCheckIn> = z.object({
+  identificationMethod: z.union([
+    z.object({
+      type: z.literal('photoId'),
+      state: z.string(),
+    }),
+    z.object({
+      type: z.literal('challengedVoterAffidavit'),
+    }),
+    z.object({
+      type: z.literal('personalRecognizance'),
+      recognizer: z.union([
+        z.literal('supervisor'),
+        z.literal('moderator'),
+        z.literal('cityClerk'),
+      ]),
+    }),
+  ]),
+  timestamp: z.string(),
+  machineId: z.string(),
+});
+
 export interface Voter {
   voterId: string;
   lastName: string;
@@ -88,6 +110,39 @@ export interface Voter {
   checkIn?: VoterCheckIn;
 }
 
+export const VoterSchema: z.ZodSchema<Voter> = z.object({
+  voterId: z.string(),
+  lastName: z.string(),
+  suffix: z.string(),
+  firstName: z.string(),
+  middleName: z.string(),
+  streetNumber: z.string(),
+  addressSuffix: z.string(),
+  houseFractionNumber: z.string(),
+  streetName: z.string(),
+  apartmentUnitNumber: z.string(),
+  addressLine2: z.string(),
+  addressLine3: z.string(),
+  postalCityTown: z.string(),
+  state: z.string(),
+  postalZip5: z.string(),
+  zip4: z.string(),
+  mailingStreetNumber: z.string(),
+  mailingSuffix: z.string(),
+  mailingHouseFractionNumber: z.string(),
+  mailingStreetName: z.string(),
+  mailingApartmentUnitNumber: z.string(),
+  mailingAddressLine2: z.string(),
+  mailingAddressLine3: z.string(),
+  mailingCityTown: z.string(),
+  mailingState: z.string(),
+  mailingZip5: z.string(),
+  mailingZip4: z.string(),
+  party: z.string(),
+  district: z.string(),
+  checkIn: VoterCheckInSchema.optional(),
+});
+
 export interface VoterSearchParams {
   lastName: string;
   firstName: string;
@@ -115,4 +170,9 @@ export interface DeviceStatuses {
   network: {
     pollbooks: Array<Pick<PollBookService, 'machineId' | 'lastSeen'>>;
   };
+}
+
+export enum EventType {
+  VoterCheckIn = 'VoterCheckIn',
+  UndoVoterCheckIn = 'UndoVoterCheckIn',
 }

--- a/backend/src/workspace.ts
+++ b/backend/src/workspace.ts
@@ -11,7 +11,8 @@ export interface Workspace {
 
 export function createWorkspace(
   workspacePath: string,
-  logger: BaseLogger
+  logger: BaseLogger,
+  machineId: string
 ): Workspace {
   ensureDirSync(workspacePath);
 
@@ -19,7 +20,7 @@ export function createWorkspace(
   ensureDirSync(assetDirectoryPath);
 
   const dbPath = join(workspacePath, 'pollbook-backend.db');
-  const store = Store.fileStore(dbPath, logger);
+  const store = Store.fileStore(dbPath, logger, machineId);
 
   return { assetDirectoryPath, store };
 }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.shared.json",
   "include": ["scripts", "src", "test"],
-  "exclude": [],
+  "exclude": ["jest.config.ts"],
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       '@jest/types':
         specifier: ^29.6.1
         version: 29.6.3
+      '@testing-library/react':
+        specifier: ^15.0.7
+        version: 15.0.7(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@types/debug':
         specifier: 4.1.8
         version: 4.1.8
@@ -145,6 +148,9 @@ importers:
       '@types/fs-extra':
         specifier: 11.0.1
         version: 11.0.1
+      '@types/jest':
+        specifier: ^29.5.3
+        version: 29.5.14
       '@types/node':
         specifier: 20.16.0
         version: 20.16.0
@@ -172,6 +178,21 @@ importers:
       is-ci-cli:
         specifier: 2.2.0
         version: 2.2.0
+      jest:
+        specifier: ^29.6.2
+        version: 29.7.0(@types/node@20.16.0)
+      jest-environment-jsdom:
+        specifier: ^29.6.2
+        version: 29.7.0(canvas@2.11.2)
+      jest-junit:
+        specifier: ^16.0.0
+        version: 16.0.0
+      jest-styled-components:
+        specifier: ^7.1.1
+        version: 7.2.0(styled-components@5.3.11)
+      jest-watch-typeahead:
+        specifier: ^2.2.2
+        version: 2.2.2(jest@29.7.0)
       lint-staged:
         specifier: 11.0.0
         version: 11.0.0
@@ -184,6 +205,9 @@ importers:
       tmp:
         specifier: ^0.2.1
         version: 0.2.3
+      ts-jest:
+        specifier: 29.1.1
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.3)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
 
   frontend:
     dependencies:
@@ -325,7 +349,7 @@ importers:
         version: 29.7.0(@types/node@20.16.0)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.7.0
+        version: 29.7.0(canvas@2.11.2)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -349,7 +373,7 @@ importers:
         version: 0.2.3
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.26.0)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.3)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
       vite:
         specifier: 4.5.2
         version: 4.5.2(@types/node@20.16.0)
@@ -487,7 +511,7 @@ importers:
         version: 1.57.0
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8
+        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -656,7 +680,7 @@ importers:
         version: 1.57.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.26.0)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.3)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
 
   libs/ballot-encoder:
     dependencies:
@@ -937,7 +961,7 @@ importers:
         version: 2.2.0
       jsdom:
         specifier: 20.0.1
-        version: 20.0.1
+        version: 20.0.1(canvas@2.11.2)
       lint-staged:
         specifier: 11.0.0
         version: 11.0.0
@@ -1028,7 +1052,7 @@ importers:
         version: 18.3.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.26.0)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.3)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
 
   libs/fixtures:
     dependencies:
@@ -1205,7 +1229,7 @@ importers:
         version: 2.2.2(jest@29.7.0)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.26.0)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.3)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
 
   libs/grout:
     dependencies:
@@ -1257,7 +1281,7 @@ importers:
         version: 1.57.0
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8
+        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
 
   libs/grout/test-utils:
     dependencies:
@@ -1288,7 +1312,7 @@ importers:
         version: 1.57.0
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8
+        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
 
   libs/image-utils:
     dependencies:
@@ -1641,7 +1665,7 @@ importers:
         version: 1.57.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.26.0)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.3)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
 
   libs/test-utils:
     dependencies:
@@ -1802,7 +1826,7 @@ importers:
         version: 1.57.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.26.0)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.3)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
 
   libs/ui:
     dependencies:
@@ -2037,7 +2061,7 @@ importers:
         version: 29.7.0(@types/node@20.16.0)
       jest-environment-jsdom:
         specifier: ^29.6.2
-        version: 29.7.0
+        version: 29.7.0(canvas@2.11.2)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -2079,7 +2103,7 @@ importers:
         version: 0.2.3
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.26.0)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.3)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
       util:
         specifier: ^0.12.4
         version: 0.12.5
@@ -2152,7 +2176,7 @@ importers:
         version: 1.57.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.26.0)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.3)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
 
   libs/utils:
     dependencies:
@@ -5041,7 +5065,6 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: false
 
   /@ndelangen/get-tarball@3.0.9:
     resolution: {integrity: sha512-9JKTEik4vq+yGosHYhZ1tiH/3WpUS0Nh0kej4Agndhox8pAdWhEx5knFVRcb/ya9knCRCs1rPxNrSXTDdfVqpA==}
@@ -6587,7 +6610,7 @@ packages:
       magicast: 0.3.5
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.8
+      vitest: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6831,7 +6854,6 @@ packages:
 
   /abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
-    dev: false
 
   /abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -7048,7 +7070,6 @@ packages:
 
   /aproba@2.0.0:
     resolution: {integrity: sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==}
-    dev: false
 
   /are-we-there-yet@2.0.0:
     resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
@@ -7057,7 +7078,6 @@ packages:
     dependencies:
       delegates: 1.0.0
       readable-stream: 3.6.2
-    dev: false
 
   /argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -7877,7 +7897,6 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: false
 
   /chai@5.1.2:
     resolution: {integrity: sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==}
@@ -8141,7 +8160,6 @@ packages:
   /color-support@1.1.3:
     resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
     hasBin: true
-    dev: false
 
   /colord@2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
@@ -8282,7 +8300,6 @@ packages:
 
   /console-control-strings@1.1.0:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
-    dev: false
 
   /constants-browserify@1.0.0:
     resolution: {integrity: sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==}
@@ -8678,7 +8695,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       mimic-response: 2.1.0
-    dev: false
 
   /decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -8804,7 +8820,6 @@ packages:
 
   /delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
-    dev: false
 
   /depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -8833,7 +8848,6 @@ packages:
   /detect-libc@2.0.3:
     resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
     engines: {node: '>=8'}
-    dev: false
 
   /detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
@@ -10403,7 +10417,6 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wide-align: 1.1.5
-    dev: false
 
   /gaxios@6.7.1:
     resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
@@ -10800,7 +10813,6 @@ packages:
 
   /has-unicode@2.0.1:
     resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
-    dev: false
 
   /has-value@0.3.1:
     resolution: {integrity: sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==}
@@ -11844,7 +11856,7 @@ packages:
       jest-util: 29.7.0
       pretty-format: 29.7.0
 
-  /jest-environment-jsdom@29.7.0:
+  /jest-environment-jsdom@29.7.0(canvas@2.11.2):
     resolution: {integrity: sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -11858,9 +11870,10 @@ packages:
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
       '@types/node': 20.16.0
+      canvas: 2.11.2
       jest-mock: 29.7.0
       jest-util: 29.7.0
-      jsdom: 20.0.3
+      jsdom: 20.0.1(canvas@2.11.2)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -12241,7 +12254,7 @@ packages:
       - supports-color
     dev: true
 
-  /jsdom@20.0.1:
+  /jsdom@20.0.1(canvas@2.11.2):
     resolution: {integrity: sha512-pksjj7Rqoa+wdpkKcLzQRHhJCEE42qQhl/xLMUKHgoSejaKOdaXEAnqs6uDNwMl/fciHTzKeR8Wm8cw7N+g98A==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -12253,6 +12266,7 @@ packages:
       abab: 2.0.6
       acorn: 8.14.0
       acorn-globals: 7.0.1
+      canvas: 2.11.2
       cssom: 0.5.0
       cssstyle: 2.3.0
       data-urls: 3.0.2
@@ -12270,47 +12284,6 @@ packages:
       symbol-tree: 3.2.4
       tough-cookie: 4.1.4
       w3c-xmlserializer: 3.0.0
-      webidl-conversions: 7.0.0
-      whatwg-encoding: 2.0.0
-      whatwg-mimetype: 3.0.0
-      whatwg-url: 11.0.0
-      ws: 8.18.0
-      xml-name-validator: 4.0.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /jsdom@20.0.3:
-    resolution: {integrity: sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      canvas: ^2.5.0
-    peerDependenciesMeta:
-      canvas:
-        optional: true
-    dependencies:
-      abab: 2.0.6
-      acorn: 8.14.0
-      acorn-globals: 7.0.1
-      cssom: 0.5.0
-      cssstyle: 2.3.0
-      data-urls: 3.0.2
-      decimal.js: 10.4.3
-      domexception: 4.0.0
-      escodegen: 2.1.0
-      form-data: 4.0.1
-      html-encoding-sniffer: 3.0.0
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
-      is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.16
-      parse5: 7.2.1
-      saxes: 6.0.0
-      symbol-tree: 3.2.4
-      tough-cookie: 4.1.4
-      w3c-xmlserializer: 4.0.0
       webidl-conversions: 7.0.0
       whatwg-encoding: 2.0.0
       whatwg-mimetype: 3.0.0
@@ -12946,7 +12919,6 @@ packages:
   /mimic-response@2.1.0:
     resolution: {integrity: sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==}
     engines: {node: '>=8'}
-    dev: false
 
   /mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -13100,7 +13072,6 @@ packages:
 
   /nan@2.22.0:
     resolution: {integrity: sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==}
-    dev: false
 
   /nanoid@3.3.8:
     resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
@@ -13252,7 +13223,6 @@ packages:
     hasBin: true
     dependencies:
       abbrev: 1.1.1
-    dev: false
 
   /normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
@@ -13316,7 +13286,6 @@ packages:
       console-control-strings: 1.1.0
       gauge: 3.0.2
       set-blocking: 2.0.0
-    dev: false
 
   /nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
@@ -14979,7 +14948,6 @@ packages:
 
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
-    dev: false
 
   /set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -15101,7 +15069,6 @@ packages:
 
   /simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
-    dev: false
 
   /simple-get@3.1.1:
     resolution: {integrity: sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==}
@@ -15109,7 +15076,6 @@ packages:
       decompress-response: 4.2.1
       once: 1.4.0
       simple-concat: 1.0.1
-    dev: false
 
   /simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
@@ -16093,7 +16059,7 @@ packages:
     engines: {node: '>=6.10'}
     dev: true
 
-  /ts-jest@29.1.1(@babel/core@7.26.0)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2):
+  /ts-jest@29.1.1(@babel/core@7.26.0)(@jest/types@29.6.3)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2):
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -16115,6 +16081,7 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.26.0
+      '@jest/types': 29.6.3
       bs-logger: 0.2.6
       esbuild: 0.21.2
       fast-json-stable-stringify: 2.1.0
@@ -16713,63 +16680,6 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@2.1.8:
-    resolution: {integrity: sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 2.1.8
-      '@vitest/ui': 2.1.8
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-    dependencies:
-      '@vitest/expect': 2.1.8
-      '@vitest/mocker': 2.1.8(vite@5.4.11)
-      '@vitest/pretty-format': 2.1.8
-      '@vitest/runner': 2.1.8
-      '@vitest/snapshot': 2.1.8
-      '@vitest/spy': 2.1.8
-      '@vitest/utils': 2.1.8
-      chai: 5.1.2
-      debug: 4.4.0
-      expect-type: 1.1.0
-      magic-string: 0.30.17
-      pathe: 1.1.2
-      std-env: 3.8.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.1
-      tinypool: 1.0.2
-      tinyrainbow: 1.2.0
-      vite: 5.4.11(@types/node@20.16.0)
-      vite-node: 2.1.8(@types/node@20.16.0)
-      why-is-node-running: 2.3.0
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
   /vitest@2.1.8(@types/node@20.16.0)(jsdom@20.0.1):
     resolution: {integrity: sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -16806,7 +16716,7 @@ packages:
       chai: 5.1.2
       debug: 4.4.0
       expect-type: 1.1.0
-      jsdom: 20.0.1
+      jsdom: 20.0.1(canvas@2.11.2)
       magic-string: 0.30.17
       pathe: 1.1.2
       std-env: 3.8.0
@@ -16847,13 +16757,6 @@ packages:
   /w3c-xmlserializer@3.0.0:
     resolution: {integrity: sha512-3WFqGEgSXIyGhOmAFtlicJNMjEps8b1MG31NCA0/vOF9+nKMUW1ckhi9cnNHmf88Rzw5V+dwIwsm2C7X8k9aQg==}
     engines: {node: '>=12'}
-    dependencies:
-      xml-name-validator: 4.0.0
-    dev: true
-
-  /w3c-xmlserializer@4.0.0:
-    resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
-    engines: {node: '>=14'}
     dependencies:
       xml-name-validator: 4.0.0
     dev: true
@@ -17109,7 +17012,6 @@ packages:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
     dependencies:
       string-width: 4.2.3
-    dev: false
 
   /word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}


### PR DESCRIPTION
Initial implementation of pollbooks syncing events and applying them to the voter table. This adds:

- Simple election table that stores election configuration for persistence on reboots
- Simple voter table that stores voter information (not check in data) for persistence on reboots
- event_log table that stores events (currently check ins and undo check ins) 

Whenever voter information is fetched all voter-related events (which is currently all events) are fetched from the db and applied, in order, to the voters before they are returned. This is not very efficient and should be optimized down the line. 

Whenever the polling interval on network connection sees a connected pollbook (new or old) we tell that pollbook the list of machines with the last synced event for each machine. The connected pollbook then tells us any events it has past our last synced event for each machine or any events it has for machines we don't know about. We then save these to our event log. 

The network polling interval logic is also updated to include more information about different pollbooks and keep knowledge of, but mark as disconnected, older pollbooks 