### PR TITLE
Improve Networking Setup Scripts

### DIFF
--- a/script/99-mesh-network.rules
+++ b/script/99-mesh-network.rules
@@ -1,1 +1,1 @@
-ACTION=="move", SUBSYSTEM=="net", ENV{ID_MODEL}=="802.11_n_WLAN", RUN+="/bin/bash /vx/scripts/setup_basic_mesh.sh"
+ACTION=="move", SUBSYSTEM=="net", ENV{ID_MODEL}=="802.11_n_WLAN", ENV{SYSTEMD_WANTS}+="join-mesh-network.service"

--- a/script/avahi-autoipd.service
+++ b/script/avahi-autoipd.service
@@ -1,13 +1,7 @@
 [Unit]
 Description=Run avahi-autoipd for mesh network
-After=join-mesh-network.service
 
 [Service]
 Type=simple
 ExecStart=sudo avahi-autoipd -D -w mesh0
 RemainAfterExit=Yes
-Restart=on-failure
-RestartSec=5s
-
-[Install]
-WantedBy=multi-user.target suspend.target sleep.target

--- a/script/avahi-autoipd.service
+++ b/script/avahi-autoipd.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Run avahi-autoipd for mesh network
+After=join-mesh-network.service
+
+[Service]
+Type=simple
+ExecStart=sudo avahi-autoipd -D -w mesh0
+RemainAfterExit=Yes
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target suspend.target sleep.target

--- a/script/initial_configuration.sh
+++ b/script/initial_configuration.sh
@@ -17,4 +17,5 @@ sudo systemctl enable join-mesh-network
 sudo systemctl enable avahi-daemon
 sudo systemctl enable avahi-autoipd
 
+sudo systemctl start avahi-autoipd
 sudo systemctl start join-mesh-network

--- a/script/initial_configuration.sh
+++ b/script/initial_configuration.sh
@@ -8,11 +8,13 @@ sudo systemctl stop firewalld
 
 sudo cp setup_basic_mesh.sh /vx/scripts/.
 sudo cp join-mesh-network.service /etc/systemd/system/.
+sudo cp avahi-autoipd.service /etc/systemd/system/.
 sudo cp 99-mesh-network.rules /etc/udev/rules.d/.
 
 sudo udevadm control --reload-rules
 sudo systemctl daemon-reload
 sudo systemctl enable join-mesh-network
-
-sudo bash /vx/scripts/setup_basic_mesh.sh
 sudo systemctl enable avahi-daemon
+sudo systemctl enable avahi-autoipd
+
+sudo systemctl start join-mesh-network

--- a/script/join-mesh-network.service
+++ b/script/join-mesh-network.service
@@ -5,7 +5,8 @@ After=sleep.target suspend.target
 [Service]
 Type=oneshot
 ExecStart=sudo /bin/bash /vx/scripts/setup_basic_mesh.sh
-ExecStartPost=/bin/systemctl restart avahi-autoipd.service
+ExecStartPre=/bin/systemctl stop avahi-autoipd.service
+ExecStartPost=/bin/systemctl start avahi-autoipd.service
 
 [Install]
 WantedBy=multi-user.target suspend.target sleep.target

--- a/script/join-mesh-network.service
+++ b/script/join-mesh-network.service
@@ -4,8 +4,9 @@ After=sleep.target suspend.target
 
 [Service]
 Type=oneshot
+ExecStartPre=/bin/systemctl stop avahi-autoipd.service
 ExecStart=sudo /bin/bash /vx/scripts/setup_basic_mesh.sh
-ExecStartPost=/bin/systemctl restart avahi-autoipd.service
+ExecStartPost=/bin/systemctl start avahi-autoipd.service
 
 [Install]
 WantedBy=multi-user.target suspend.target sleep.target

--- a/script/join-mesh-network.service
+++ b/script/join-mesh-network.service
@@ -5,8 +5,7 @@ After=sleep.target suspend.target
 [Service]
 Type=oneshot
 ExecStart=sudo /bin/bash /vx/scripts/setup_basic_mesh.sh
-ExecStartPre=/bin/systemctl stop avahi-autoipd.service
-ExecStartPost=/bin/systemctl start avahi-autoipd.service
+ExecStartPost=/bin/systemctl restart avahi-autoipd.service
 
 [Install]
 WantedBy=multi-user.target suspend.target sleep.target

--- a/script/join-mesh-network.service
+++ b/script/join-mesh-network.service
@@ -1,9 +1,11 @@
 [Unit]
 Description=Join mesh network on boot and resume from suspend
+After=sleep.target suspend.target
 
 [Service]
 Type=oneshot
 ExecStart=sudo /bin/bash /vx/scripts/setup_basic_mesh.sh
+ExecStartPost=/bin/systemctl restart avahi-autoipd.service
 
 [Install]
-WantedBy=multi-user.target sleep.target
+WantedBy=multi-user.target suspend.target sleep.target

--- a/script/setup_basic_mesh.sh
+++ b/script/setup_basic_mesh.sh
@@ -38,7 +38,4 @@ echo "Bringing up the network and joining pollbook_mesh"
 sudo ip link set mesh0 up
 sudo iw dev mesh0 mesh join pollbook_mesh
 
-# Use avahi-autoipd to get a link-local IP address
-sudo avahi-autoipd -D -w mesh0
-
 echo "Successfully joined the network."


### PR DESCRIPTION
Makes the following improvements to harden the networking setup:
- Updates the udev rule to trigger the join-mesh-network.service service file so that everything goes through that. The udev rule will trigger it when a new wifi adapter is seen, the service file itself has triggers for machine boot, sleep and suspend resumption. 
- Creates a second service file that keeps running after trigger to manage running avahi-autoipd which assigns an IP address on IPv4 to the mesh network interface. If this occurs in the oneshot script then it will send a stop command to avahi-autoipd and the ip address is removed when the service file completes. If we make the entire mesh network service keep running its hard to make it restart properly. 
- Manually restarts the avahi-autoipd service upon completion of the join-mesh-network.service to get the ip addressing running. 

Tested the following: 
- removing and reinserting wifi adapter
- suspending computer and bringing back to life
- restarting

To verify the network is auto setup and active without intervention 