### PR TITLE
Order events with distributed vector clocks

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -14,6 +14,7 @@ CREATE TABLE event_log (
     timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     event_type TEXT, -- e.g., "check_in", "undo_check_in"
     voter_id TEXT, -- voter_id of the voter involved in the event, if any
+    vector_clock TEXT, -- JSON data for the vector clock at the time of the event
     event_data TEXT not null, -- JSON data for additional details associated with the event (id type used for check in, etc.)
     PRIMARY KEY (event_id, machine_id)
 );

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -34,6 +34,7 @@ import {
   PollbookConnectionStatus,
   PollbookEvent,
   PollbookPackage,
+  VectorClock,
   Voter,
   VoterIdentificationMethod,
   VoterSearchParams,
@@ -256,9 +257,9 @@ async function setupMachineNetworking({
             );
           }
           // Sync events from this pollbook service.
-          const knownMachines = workspace.store.getKnownMachinesWithEventIds();
+          const currentClock = workspace.store.getCurrentClock();
           const events = await apiClient.getEvents({
-            knownMachines,
+            currentClock,
           });
           workspace.store.saveEvents(events);
 
@@ -412,10 +413,8 @@ function buildApi(context: AppContext) {
       return store.saveEvent(input.pollbookEvent);
     },
 
-    getEvents(input: {
-      knownMachines: Record<string, number>;
-    }): PollbookEvent[] {
-      return store.getNewEvents(input.knownMachines);
+    getEvents(input: { currentClock: VectorClock }): PollbookEvent[] {
+      return store.getNewEvents(input.currentClock);
     },
   });
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -358,12 +358,7 @@ function buildApi(context: AppContext) {
       voterId: string;
       identificationMethod: VoterIdentificationMethod;
     }): Promise<boolean> {
-      const timestamp = new Date();
-      const { voter, count } = store.recordVoterCheckIn({
-        ...input,
-        machineId,
-        timestamp,
-      });
+      const { voter, count } = store.recordVoterCheckIn(input);
 
       const receipt = React.createElement(CheckInReceipt, {
         voter,

--- a/backend/src/store.ts
+++ b/backend/src/store.ts
@@ -60,17 +60,10 @@ export class Store {
       this.vectorClock[this.machineId] = 0;
     }
     this.vectorClock[this.machineId] += 1;
-    console.log('Incremented vector clock', this.vectorClock);
     return this.vectorClock[this.machineId];
   }
 
   private updateLocalVectorClock(remoteClock: VectorClock) {
-    console.log(
-      'Merging clocks, local:',
-      this.vectorClock,
-      'remote:',
-      remoteClock
-    );
     this.vectorClock = mergeVectorClocks(this.vectorClock, remoteClock);
   }
 
@@ -119,7 +112,6 @@ export class Store {
     if (!rows) {
       return voters;
     }
-    console.log(rows);
 
     const events = rows.map((row) => ({
       ...row,
@@ -128,7 +120,6 @@ export class Store {
         VectorClockSchema
       ).unsafeUnwrap(),
     }));
-    console.log(events);
 
     // Order events by the vector clocks, concurrent events are ordered by machine_id.
     const orderedEvents = [...events].sort((a, b) => {
@@ -143,6 +134,7 @@ export class Store {
     });
 
     for (const event of orderedEvents) {
+      this.updateLocalVectorClock(event.vector_clock);
       switch (event.event_type) {
         case EventType.VoterCheckIn: {
           const voter = find(voters, (v) => v.voterId === event.voter_id);

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -148,11 +148,16 @@ export interface MachineInformation {
   configuredElectionId?: string;
 }
 
+export type VectorClock = Record<string, number>;
+
+export const VectorClockSchema: z.ZodSchema<VectorClock> = z.record(z.number());
+
 export interface PollbookEvent {
   type: EventType;
   eventId: number;
   machineId: string;
   timestamp: string;
+  vectorClock: VectorClock;
 }
 
 export interface VoterCheckInEvent extends PollbookEvent {
@@ -221,4 +226,5 @@ export interface EventDbRow {
   event_type: EventType;
   timestamp: string;
   event_data: string;
+  vector_clock: string;
 }

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -184,7 +184,6 @@ export interface PollbookPackage {
 export interface PollBookService {
   apiClient?: grout.Client<Api>;
   machineId: string;
-  lastEventIdReceived?: string;
   lastSeen: Date;
   status: PollbookConnectionStatus;
 }

--- a/backend/src/vector_clock.test.ts
+++ b/backend/src/vector_clock.test.ts
@@ -1,0 +1,51 @@
+import {
+  mergeVectorClocks,
+  compareVectorClocks,
+  isLater,
+} from './vector_clock';
+import { VectorClock } from './types';
+
+describe('Vector Clock Utilities', () => {
+  test('mergeVectorClocks', () => {
+    const clock1: VectorClock = { m1: 1, m2: 2 };
+    const clock2: VectorClock = { m2: 3, m3: 1 };
+    const mergedClock = mergeVectorClocks(clock1, clock2);
+    expect(mergedClock).toEqual({ m1: 1, m2: 3, m3: 1 });
+  });
+
+  test('compareVectorClocks - causally before', () => {
+    const clock1: VectorClock = { m1: 1, m2: 2 };
+    const clock2: VectorClock = { m1: 1, m2: 3 };
+    const clock3: VectorClock = { m1: 2, m2: 3 };
+    expect(compareVectorClocks(clock1, clock2)).toEqual(-1);
+    expect(compareVectorClocks(clock1, clock3)).toEqual(-1);
+    expect(compareVectorClocks(clock2, clock3)).toEqual(-1);
+  });
+
+  test('compareVectorClocks - causally after', () => {
+    const clock1: VectorClock = { m1: 2, m2: 3 };
+    const clock2: VectorClock = { m1: 2, m2: 2 };
+    const clock3: VectorClock = { m1: 1, m2: 2 };
+    expect(compareVectorClocks(clock1, clock2)).toEqual(1);
+    expect(compareVectorClocks(clock1, clock3)).toEqual(1);
+    expect(compareVectorClocks(clock2, clock3)).toEqual(1);
+  });
+
+  test('compareVectorClocks - concurrent', () => {
+    const clock1: VectorClock = { m1: 2, m2: 3 };
+    const clock2: VectorClock = { m1: 2, m2: 3 };
+    expect(compareVectorClocks(clock1, clock2)).toEqual(0);
+
+    const clock3: VectorClock = { m1: 1, m2: 4 };
+    expect(compareVectorClocks(clock1, clock3)).toEqual(0);
+    expect(compareVectorClocks(clock3, clock1)).toEqual(0);
+  });
+
+  test('isLater', () => {
+    const clock1: VectorClock = { m1: 2, m2: 2 };
+    const clock2: VectorClock = { m1: 1, m2: 3 };
+    expect(isLater(clock1, clock2)).toEqual(true);
+    expect(isLater(clock2, clock1)).toEqual(true);
+    expect(isLater(clock1, clock1)).toEqual(false);
+  });
+});

--- a/backend/src/vector_clock.ts
+++ b/backend/src/vector_clock.ts
@@ -36,7 +36,6 @@ export function compareVectorClocks(
   clock1: VectorClock,
   clock2: VectorClock
 ): number {
-  console.log(clock1, clock2);
   let isBefore = false;
   let isAfter = false;
   const keys = new Set([...Object.keys(clock1), ...Object.keys(clock2)]);

--- a/backend/src/vector_clock.ts
+++ b/backend/src/vector_clock.ts
@@ -1,0 +1,66 @@
+// Helper functions for working with vector clocks
+
+import { VectorClock } from './types';
+
+// Merges two vector clocks, taking the maximum value for each key and returning the merged clock.
+export function mergeVectorClocks(
+  clock1: VectorClock,
+  clock2: VectorClock
+): VectorClock {
+  const mergedClock: VectorClock = { ...clock1 };
+  for (const [key, value] of Object.entries(clock2)) {
+    if (mergedClock[key] === undefined || mergedClock[key] < value) {
+      mergedClock[key] = value;
+    }
+  }
+  return mergedClock;
+}
+
+// Returns true if the first clock is later then the second clock
+// This does not mean that the first clock is causally after the second clock, only has at least one node that it is later.
+export function isLater(clock1: VectorClock, clock2: VectorClock): boolean {
+  const keys = new Set([...Object.keys(clock1), ...Object.keys(clock2)]);
+  for (const key of keys) {
+    if ((clock1[key] || -1) > (clock2[key] || -1)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Compares two vector clocks.
+// If a is causally before b, returns -1. This means that every event in A happened before or at the same time as every event in B with at least one event being before.
+// If a is causally after b, returns 1. This means that every event in A happened after or at the same time as every event in B with at least one event being after.
+// If the events are concurrent, all clock events are identical or there are some events before and some after, returns 0. This means that there is no causal relationship between the two clocks and another deterministic method should be used to order events consistently.
+export function compareVectorClocks(
+  clock1: VectorClock,
+  clock2: VectorClock
+): number {
+  console.log(clock1, clock2);
+  let isBefore = false;
+  let isAfter = false;
+  const keys = new Set([...Object.keys(clock1), ...Object.keys(clock2)]);
+
+  for (const key of keys) {
+    const aValue = clock1[key] || -1;
+    const bValue = clock2[key] || -1;
+
+    if (aValue < bValue) {
+      isBefore = true;
+    } else if (aValue > bValue) {
+      isAfter = true;
+    }
+
+    if (isBefore && isAfter) {
+      return 0; // Concurrent
+    }
+  }
+
+  if (isBefore) {
+    return -1; // a is causally before b
+  }
+  if (isAfter) {
+    return 1; // a is causally after b
+  }
+  return 0; // Identical
+}


### PR DESCRIPTION
We were essentially already implementing vector clocks in order to determine what events we needed to fetch when updating nodes, this PR formalizes that implementation a bit and uses the vector clocks for ordering events. In order to order events deterministically there needs to be a tie breaker for "concurrent" vector clocks. Consider the following simple example: 
NodeA comes online and checks in Bob, that event has a clock of 1 and the vector {NodeA: 1}
NodeB comes online and checks in Greg (before syncing) that event also has a time of one with the vector: {NodeB: 1} 

How do we determine which happened first? Well it doesn't really matter so we break the tie by defaulting to sorting on machineId. If NodeB had synced with NodeA before the check in the vector would look like {NodeA: 1, NodeB:1} which would be causally after the Bob event. 