### PR TITLE
refetch counts and tiebreak clocks by timestamp

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -151,7 +151,9 @@ export const getCheckInCounts = {
   },
   useQuery() {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getCheckInCounts());
+    return useQuery(this.queryKey(), () => apiClient.getCheckInCounts(), {
+      refetchInterval: 1000,
+    });
   },
 } as const;
 


### PR DESCRIPTION
Two small tweaks
- Adds a refetch interval for the get check in count query (cc @jonahkagan ) so that that auto-updates
- Changes the way concurrent vector clocks are tiebroken for ordering event to fallback to system timestamp instead of machine ID. I realized this is better for the following scenario:
Machine A goes offline: While offline it checks in Joe and then undoes that checkin
Machine B: Checks in Joe , several real time minutes later
When Machine A comes back online we want to try to ensure that the undo is ordered before the check in from Machine B. Since the machines were not connected when this all happeend the vector clocks will be concurrent, obviously system time could be wrong here and there is no way to ever completely guarantee we always properly order everything but I think falling back to system time (in addition to adding a safeguard for them not being TOO off from each other) is likely the best approach. 