### PR TITLE
Build out simulation script a bit more

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -68,6 +68,7 @@
     "@types/styled-components": "^5.1.26",
     "@types/tmp": "0.2.4",
     "@types/uuid": "9.0.5",
+    "@types/yargs": "17.0.22",
     "esbuild": "0.21.2",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
@@ -81,7 +82,8 @@
     "nodemon": "^3.1.7",
     "sort-package-json": "^1.50.0",
     "tmp": "^0.2.1",
-    "ts-jest": "29.1.1"
+    "ts-jest": "29.1.1",
+    "yargs": "17.7.1"
   },
   "engines": {
     "node": ">= 12"

--- a/backend/scripts/simulate-check-ins
+++ b/backend/scripts/simulate-check-ins
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+require('esbuild-runner').install({
+  type: 'transform',
+});
+
+require('./simulate_check_ins')
+  .main(process.argv)
+  .then((exitCode) => {
+    process.exitCode = exitCode;
+  });

--- a/backend/scripts/simulate_check_ins.ts
+++ b/backend/scripts/simulate_check_ins.ts
@@ -1,5 +1,6 @@
 import * as grout from '@votingworks/grout';
-import { safeParseInt } from '@votingworks/types';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 import type { Api } from '../src/app';
 
 const api = grout.createClient<Api>({
@@ -7,8 +8,13 @@ const api = grout.createClient<Api>({
 });
 
 async function getAllVoters() {
-  const response = await api.getAllVoters();
-  return response;
+  try {
+    const response = await api.getAllVoters();
+    return response;
+  } catch (error) {
+    console.error('Failed to fetch voters:', error);
+    return []; // Return an empty array if offline
+  }
 }
 
 async function checkInVoter(voterId: string) {
@@ -25,22 +31,54 @@ async function checkInVoter(voterId: string) {
   }
 }
 
-async function checkInAllVotersOnCurrentMachine(limit?: number) {
+function isVoterInRange(voter: { lastName: string }, range: string): boolean {
+  const [start, end] = range.split('-').map((char) => char.toUpperCase());
+  const lastNameInitial = voter.lastName[0].toUpperCase();
+  return lastNameInitial >= start && lastNameInitial <= end;
+}
+
+async function checkInAllVotersOnCurrentMachine(
+  limit?: number,
+  range?: string,
+  slow?: boolean
+) {
   try {
     console.log('Starting check-in simulation...');
-    const voters = await getAllVoters();
-    const votersToProcess = limit ? voters.slice(0, limit) : voters;
+    let voters = await getAllVoters();
+
+    if (range) {
+      voters = voters.filter((voter) => isVoterInRange(voter, range));
+    }
+
+    const sortedVoters = [...voters].sort((a, b) => {
+      const lastNameComparison = a.lastName.localeCompare(b.lastName);
+      return lastNameComparison !== 0
+        ? lastNameComparison
+        : a.firstName.localeCompare(b.firstName);
+    });
+
+    const votersToProcess = limit ? sortedVoters.slice(0, limit) : sortedVoters;
     console.log(
-      `Found ${voters.length} voters, will process ${votersToProcess.length}`
+      `Found ${sortedVoters.length} voters, will process ${votersToProcess.length}`
     );
 
     let processed = 0;
     for (const voter of votersToProcess) {
+      if (slow) {
+        console.log('checking in voter', voter);
+      }
       await checkInVoter(voter.voterId);
       processed += 1;
 
       if (processed % 100 === 0) {
         console.log(`Processed ${processed} voters`);
+      }
+
+      if (slow) {
+        const delay = Math.floor(Math.random() * 4000) + 4000; // Random delay between 4 and 8 seconds
+        await new Promise((resolve) => {
+          setTimeout(resolve, delay);
+        });
       }
     }
 
@@ -50,8 +88,40 @@ async function checkInAllVotersOnCurrentMachine(limit?: number) {
   }
 }
 
-// Parse command line argument
-const voterLimit = process.argv[2]
-  ? safeParseInt(process.argv[2]).unsafeUnwrap()
-  : undefined;
-void checkInAllVotersOnCurrentMachine(voterLimit);
+interface SimulateScriptArguments {
+  limit?: number;
+  range?: string;
+  slow: boolean;
+}
+
+export async function main(argv: string[]): Promise<void> {
+  // Parse command line arguments using yargs
+  const parser = yargs()
+    .strict()
+    .exitProcess(false)
+    .options({
+      limit: {
+        type: 'number',
+        alias: 'l',
+        description: 'Limit the number of voters to check in',
+      },
+      range: {
+        type: 'string',
+        alias: 'r',
+        description: 'Specify a range of letters for last names (e.g., A-D)',
+      },
+      slow: {
+        type: 'boolean',
+        description: 'Enable slow mode with random delays between check-ins',
+        default: false,
+      },
+    })
+    .help();
+  const args = (await parser.parse(hideBin(argv))) as SimulateScriptArguments;
+
+  const { limit, slow } = args;
+  const range =
+    args.range && /^[A-Z]-[A-Z]$/i.test(args.range) ? args.range : undefined;
+
+  await checkInAllVotersOnCurrentMachine(limit, range, slow);
+}

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -352,12 +352,12 @@ function buildApi(context: AppContext) {
         battery: batteryStatus ?? undefined,
         network: {
           isOnline: store.getIsOnline(),
-          pollbooks: store
-            .getAllConnectedPollbookServices()
-            .map((pollbook) => ({
-              machineId: pollbook.machineId,
-              lastSeen: pollbook.lastSeen,
-            })),
+          pollbooks: store.getPollbookServiceInfo().map((pollbook) => ({
+            machineId: pollbook.machineId,
+            lastSeen: pollbook.lastSeen,
+            numCheckIns: pollbook.numCheckIns,
+            status: pollbook.status,
+          })),
         },
       };
     },

--- a/backend/src/store.ts
+++ b/backend/src/store.ts
@@ -10,6 +10,7 @@ import {
   typedAs,
 } from '@votingworks/basics';
 import { safeParseJson } from '@votingworks/types';
+import { get } from 'node:http';
 import { rootDebug } from './debug';
 import {
   ConnectedPollbookService,
@@ -20,6 +21,7 @@ import {
   PollbookConnectionStatus,
   PollbookEvent,
   PollbookService,
+  PollbookServiceInfo,
   UndoVoterCheckInEvent,
   Voter,
   VoterCheckInEvent,
@@ -544,12 +546,11 @@ export class Store {
     this.connectedPollbooks[avahiServiceName] = pollbookService;
   }
 
-  getAllConnectedPollbookServices(): ConnectedPollbookService[] {
-    return Object.values(this.connectedPollbooks).filter(
-      (service): service is ConnectedPollbookService =>
-        service.status === PollbookConnectionStatus.Connected &&
-        !!service.apiClient
-    );
+  getPollbookServiceInfo(): PollbookServiceInfo[] {
+    return Object.values(this.connectedPollbooks).map((service) => ({
+      ...service,
+      numCheckIns: this.getCheckInCount(service.machineId),
+    }));
   }
 
   cleanupStalePollbookServices(): void {

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -9,7 +9,7 @@ import {
 import { BatteryInfo } from '@votingworks/backend';
 import { UsbDriveStatus } from '@votingworks/usb-drive';
 import type { Api } from './app';
-import { HlcTimestamp, HybridLogicalClock } from './hybrid_logical_clock';
+import { HlcTimestamp } from './hybrid_logical_clock';
 
 export type Election = Pick<
   VxSuiteElection,
@@ -193,8 +193,13 @@ export interface ConnectedPollbookService extends PollbookService {
   apiClient: grout.Client<Api>;
 }
 
+export interface PollbookServiceInfo
+  extends Omit<PollbookService, 'apiClient'> {
+  numCheckIns: number;
+}
+
 export interface NetworkStatus {
-  pollbooks: Array<Pick<PollbookService, 'machineId' | 'lastSeen'>>;
+  pollbooks: PollbookServiceInfo[];
   isOnline: boolean;
 }
 
@@ -204,7 +209,7 @@ export interface DeviceStatuses {
   usbDrive: UsbDriveStatus;
   network: {
     isOnline: boolean;
-    pollbooks: Array<Pick<PollbookService, 'machineId' | 'lastSeen'>>;
+    pollbooks: PollbookServiceInfo[];
   };
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,6 @@
+export enum PollbookConnectionStatus {
+  Connected = 'Connected',
+  ShutDown = 'ShutDown',
+  LostConnection = 'LostConnection',
+  WrongElection = 'WrongElection',
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       '@types/uuid':
         specifier: 9.0.5
         version: 9.0.5
+      '@types/yargs':
+        specifier: 17.0.22
+        version: 17.0.22
       esbuild:
         specifier: 0.21.2
         version: 0.21.2
@@ -204,6 +207,9 @@ importers:
       ts-jest:
         specifier: 29.1.1
         version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.3)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
+      yargs:
+        specifier: 17.7.1
+        version: 17.7.1
 
   frontend:
     dependencies:


### PR DESCRIPTION
Simulation script can be run with ./script/simulate-check-ins from vxpollbook/backend. 
It has a few optional arguments:
-l or --limit to specify a limit on the number of voters to check in
--slow will go in a more "real world" speed sleeping for a random amount of time between 4 and 8 seconds between each check in, if omitted check ins happen as fast as possible
--range or -r to specify a range of first letters for the last name to start with, i.e.  -r A-D will make the script only check in voters with last names starting with A-D. 

I find it useful to run different machines in --slow mode with different ranges so that you can more easily see what events you have from what machines. And make sure there are certain sets of voters that will not be auto checked in if you want to add in manual check-ins or undos 

Also adds a rough cut modal that shows network status information when you click on the network icon in the header. I'm sure @jonahkagan can make this prettier and a hoverable tooltip or something. But having this information available is helpful when testing things with the simulation script. It shows all pollbooks we have ever seen, a checkmark indicates an active connection, a warning icon is a lost connection or shutdown pollbook, and a red x is a machine not configured for the same election. We also show the last time we have a known sync with that pollbook and the number of check-ins we currently have for that pollbook. 