### PR TITLE
Add networking reset fallback

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,8 +1,7 @@
 import * as grout from '@votingworks/grout';
 import express, { Application } from 'express';
-import { err, ok, Result, sleep } from '@votingworks/basics';
+import { err, ok, Result } from '@votingworks/basics';
 import { DEFAULT_SYSTEM_SETTINGS, PrinterStatus } from '@votingworks/types';
-import { setInterval } from 'node:timers/promises';
 import { DippedSmartCardAuthMachineState } from '@votingworks/auth';
 import { renderToPdf } from '@votingworks/printing';
 import React from 'react';
@@ -13,7 +12,6 @@ import {
   DeviceStatuses,
   Election,
   MachineInformation,
-  PollbookConnectionStatus,
   PollbookEvent,
   Voter,
   VoterIdentificationMethod,
@@ -22,26 +20,13 @@ import {
   ValidStreetInfo,
   VoterRegistrationRequest,
 } from './types';
-import { AvahiService } from './avahi';
 import { rootDebug } from './debug';
-import {
-  NETWORK_POLLING_INTERVAL,
-  NETWORK_REQUEST_TIMEOUT,
-  PORT,
-} from './globals';
 import { CheckInReceipt } from './check_in_receipt';
 import { pollUsbDriveForPollbookPackage } from './pollbook_package';
 import { RegistrationReceipt } from './registration_receipt';
+import { resetNetworkSetup, setupMachineNetworking } from './networking';
 
 const debug = rootDebug;
-
-function createApiClientForAddress(address: string): grout.Client<Api> {
-  debug('Creating API client for address %s', address);
-  return grout.createClient<Api>({
-    baseUrl: `${address}/api`,
-    timeout: NETWORK_REQUEST_TIMEOUT,
-  });
-}
 
 function constructAuthMachineState(
   workspace: Workspace
@@ -54,133 +39,6 @@ function constructAuthMachineState(
       date: election.date,
     },
   };
-}
-
-async function setupMachineNetworking({
-  machineId,
-  workspace,
-}: AppContext): Promise<void> {
-  const currentNodeServiceName = `Pollbook-${machineId}`;
-  // Advertise a service for this machine
-  debug('Publishing service %s on port %d', currentNodeServiceName, PORT);
-  await AvahiService.advertiseHttpService(currentNodeServiceName, PORT);
-
-  // Poll every 5s for new machines on the network
-  process.nextTick(async () => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    for await (const _ of setInterval(NETWORK_POLLING_INTERVAL)) {
-      if (!(await AvahiService.hasOnlineInterface())) {
-        // There is no network to try to connect over. Bail out.
-        debug(
-          'No online interface found. Setting online status to false and bailing.'
-        );
-        workspace.store.setOnlineStatus(false);
-        continue;
-      }
-
-      const currentElection = workspace.store.getElection();
-      debug('Polling network for new machines');
-      const services = await AvahiService.discoverHttpServices();
-      const previouslyConnected = workspace.store.getPollbookServicesByName();
-      // If there are any services that were previously connected that no longer show up in avahi
-      // Mark them as shut down
-      for (const [name, service] of Object.entries(previouslyConnected)) {
-        if (!services.some((s) => s.name === name)) {
-          debug(
-            'Marking %s as shut down as it is no longer published on Avahi',
-            name
-          );
-          workspace.store.setPollbookServiceForName(name, {
-            ...service,
-            apiClient: undefined,
-            status: PollbookConnectionStatus.ShutDown,
-          });
-        }
-      }
-      if (!services.some((s) => s.name === currentNodeServiceName)) {
-        // If the current machine is no longer published on Avahi, mark as offline
-        debug(
-          'Current service no longer found on avahi. Setting online status to false'
-        );
-        workspace.store.setOnlineStatus(false);
-        continue;
-      }
-      for (const { name, host, port } of services) {
-        if (name !== currentNodeServiceName && !workspace.store.getIsOnline()) {
-          // do not bother trying to ping other nodes if we are not online
-          continue;
-        }
-        const currentPollbookService = previouslyConnected[name];
-        const apiClient =
-          currentPollbookService && currentPollbookService.apiClient
-            ? currentPollbookService.apiClient
-            : createApiClientForAddress(`http://${host}:${port}`);
-
-        try {
-          const machineInformation = await apiClient.getMachineInformation();
-          if (name === currentNodeServiceName) {
-            // current machine, if we got here the network is working
-            if (workspace.store.getIsOnline() === false) {
-              debug('Setting online status to true');
-            }
-            workspace.store.setOnlineStatus(true);
-            continue;
-          }
-          if (
-            !currentElection ||
-            currentElection.id !== machineInformation.configuredElectionId
-          ) {
-            // Only connect if the two machines are configured for the same election.
-            workspace.store.setPollbookServiceForName(name, {
-              machineId: machineInformation.machineId,
-              apiClient,
-              lastSeen: new Date(),
-              status: PollbookConnectionStatus.WrongElection,
-            });
-            continue;
-          }
-          if (
-            !currentPollbookService ||
-            currentPollbookService.status !== PollbookConnectionStatus.Connected
-          ) {
-            debug(
-              'Establishing connection with a new pollbook service with machineId %s',
-              machineInformation.machineId
-            );
-          }
-          // Sync events from this pollbook service.
-          let syncMoreEvents = true;
-          while (syncMoreEvents) {
-            const lastEventSyncedPerNode =
-              workspace.store.getLastEventSyncedPerNode();
-            const { events, hasMore } = await apiClient.getEvents({
-              lastEventSyncedPerNode,
-            });
-            workspace.store.saveRemoteEvents(events);
-            syncMoreEvents = hasMore;
-          }
-
-          // Mark as connected so future events automatically sync.
-          workspace.store.setPollbookServiceForName(name, {
-            machineId: machineInformation.machineId,
-            apiClient,
-            lastSeen: new Date(),
-            status: PollbookConnectionStatus.Connected,
-          });
-        } catch (error) {
-          if (name === currentNodeServiceName) {
-            // Could not ping our own machine, mark as offline
-            debug('Failed to establish connection to self: %s', error);
-            debug('Setting online status to false');
-            workspace.store.setOnlineStatus(false);
-          }
-          debug(`Failed to establish connection from ${name}: ${error}`);
-        }
-      }
-      // Clean up stale machines
-      workspace.store.cleanupStalePollbookServices();
-    }
-  });
 }
 
 function buildApi(context: AppContext) {
@@ -364,6 +222,11 @@ function buildApi(context: AppContext) {
       lastName: string;
     }> {
       return store.getAllVoters();
+    },
+
+    async resetNetwork(): Promise<boolean> {
+      await resetNetworkSetup(context.machineId);
+      return true;
     },
   });
 }

--- a/backend/src/avahi.ts
+++ b/backend/src/avahi.ts
@@ -55,11 +55,6 @@ export class AvahiService {
     }
   }
 
-  static cleanup(): void {
-    debug('Cleaning up Avahi service');
-    this.stopAdvertisedService();
-  }
-
   /**
    * Discovers HTTP services on the local network.
    * @returns A promise resolving to an array of discovered services.
@@ -103,18 +98,5 @@ export class AvahiService {
     }
 
     return services;
-  }
-
-  // Checks if there is any network interface 'UP'.
-  static async hasOnlineInterface(): Promise<boolean> {
-    const command = 'ip link show | grep "state UP"';
-    try {
-      const { stdout, stderr } = await execPromise(command);
-      debug(`ip link show stdout: ${stdout}`);
-      return stdout.length > 0;
-    } catch (error) {
-      debug(`Error running ip link show: ${error}`);
-      return false;
-    }
   }
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -64,13 +64,13 @@ function main(): Promise<number> {
 
 // Ensure the running process is killed when the server is killed
 process.on('exit', () => {
-  AvahiService.cleanup();
+  AvahiService.stopAdvertisedService();
 });
 
 // Optionally handle other termination signals
 for (const signal of ['SIGINT', 'SIGTERM']) {
   process.on(signal, () => {
-    AvahiService.cleanup();
+    AvahiService.stopAdvertisedService();
     process.exit();
   });
 }

--- a/backend/src/networking.ts
+++ b/backend/src/networking.ts
@@ -1,0 +1,187 @@
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import { setInterval } from 'node:timers/promises';
+import * as grout from '@votingworks/grout';
+import { sleep } from '@votingworks/basics';
+import { rootDebug } from './debug';
+import { AppContext, PollbookConnectionStatus } from './types';
+import { AvahiService } from './avahi';
+import {
+  NETWORK_POLLING_INTERVAL,
+  NETWORK_REQUEST_TIMEOUT,
+  PORT,
+} from './globals';
+import type { Api } from './app';
+
+const debug = rootDebug.extend('networking');
+
+const execPromise = promisify(exec);
+// Checks if there is any network interface 'UP'.
+export async function hasOnlineInterface(): Promise<boolean> {
+  const command = 'ip link show | grep "state UP"';
+  try {
+    const { stdout, stderr } = await execPromise(command);
+    debug(`ip link show stdout: ${stdout}`);
+    return stdout.length > 0;
+  } catch (error) {
+    debug(`Error running ip link show: ${error}`);
+    return false;
+  }
+}
+
+export async function resetNetworkSetup(machineId: string): Promise<void> {
+  const command = 'sudo systemctl start join-mesh-network';
+  try {
+    debug('Removing published service before reset.');
+    AvahiService.stopAdvertisedService();
+    debug('Triggering network reset.');
+    await execPromise(command);
+    const currentNodeServiceName = `Pollbook-${machineId}`;
+    // Advertise a service for this machine
+    debug(
+      'Publishing avahi service %s on port %d',
+      currentNodeServiceName,
+      PORT
+    );
+    await sleep(5000);
+    await AvahiService.advertiseHttpService(currentNodeServiceName, PORT);
+    debug('Network restarted');
+  } catch (error) {
+    debug(`Error restarting network: ${error}`);
+  }
+}
+
+function createApiClientForAddress(address: string): grout.Client<Api> {
+  debug('Creating API client for address %s', address);
+  return grout.createClient<Api>({
+    baseUrl: `${address}/api`,
+    timeout: NETWORK_REQUEST_TIMEOUT,
+  });
+}
+
+export async function setupMachineNetworking({
+  machineId,
+  workspace,
+}: AppContext): Promise<void> {
+  const currentNodeServiceName = `Pollbook-${machineId}`;
+  // Advertise a service for this machine
+  debug('Publishing avahi service %s on port %d', currentNodeServiceName, PORT);
+  await AvahiService.advertiseHttpService(currentNodeServiceName, PORT);
+
+  // Poll every 5s for new machines on the network
+  process.nextTick(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _ of setInterval(NETWORK_POLLING_INTERVAL)) {
+      if (!(await hasOnlineInterface())) {
+        // There is no network to try to connect over. Bail out.
+        debug(
+          'No online interface found. Setting online status to false and bailing.'
+        );
+        workspace.store.setOnlineStatus(false);
+        continue;
+      }
+
+      const currentElection = workspace.store.getElection();
+      debug('Polling network for new machines');
+      const services = await AvahiService.discoverHttpServices();
+      const previouslyConnected = workspace.store.getPollbookServicesByName();
+      // If there are any services that were previously connected that no longer show up in avahi
+      // Mark them as shut down
+      for (const [name, service] of Object.entries(previouslyConnected)) {
+        if (!services.some((s) => s.name === name)) {
+          debug(
+            'Marking %s as shut down as it is no longer published on Avahi',
+            name
+          );
+          workspace.store.setPollbookServiceForName(name, {
+            ...service,
+            apiClient: undefined,
+            status: PollbookConnectionStatus.ShutDown,
+          });
+        }
+      }
+      if (!services.some((s) => s.name === currentNodeServiceName)) {
+        // If the current machine is no longer published on Avahi, mark as offline
+        debug(
+          'The current service is no longer found on avahi. Setting online status to false'
+        );
+        workspace.store.setOnlineStatus(false);
+        continue;
+      }
+      for (const { name, host, port } of services) {
+        if (name !== currentNodeServiceName && !workspace.store.getIsOnline()) {
+          // do not bother trying to ping other nodes if we are not online
+          continue;
+        }
+        const currentPollbookService = previouslyConnected[name];
+        const apiClient =
+          currentPollbookService && currentPollbookService.apiClient
+            ? currentPollbookService.apiClient
+            : createApiClientForAddress(`http://${host}:${port}`);
+
+        try {
+          const machineInformation = await apiClient.getMachineInformation();
+          if (name === currentNodeServiceName) {
+            // current machine, if we got here the network is working
+            if (workspace.store.getIsOnline() === false) {
+              debug('Setting online status to true');
+            }
+            workspace.store.setOnlineStatus(true);
+            continue;
+          }
+          if (
+            !currentElection ||
+            currentElection.id !== machineInformation.configuredElectionId
+          ) {
+            // Only connect if the two machines are configured for the same election.
+            workspace.store.setPollbookServiceForName(name, {
+              machineId: machineInformation.machineId,
+              apiClient,
+              lastSeen: new Date(),
+              status: PollbookConnectionStatus.WrongElection,
+            });
+            continue;
+          }
+          if (
+            !currentPollbookService ||
+            currentPollbookService.status !== PollbookConnectionStatus.Connected
+          ) {
+            debug(
+              'Establishing connection with a new pollbook service with machineId %s',
+              machineInformation.machineId
+            );
+          }
+          // Sync events from this pollbook service.
+          let syncMoreEvents = true;
+          while (syncMoreEvents) {
+            const lastEventSyncedPerNode =
+              workspace.store.getLastEventSyncedPerNode();
+            const { events, hasMore } = await apiClient.getEvents({
+              lastEventSyncedPerNode,
+            });
+            workspace.store.saveRemoteEvents(events);
+            syncMoreEvents = hasMore;
+          }
+
+          // Mark as connected so future events automatically sync.
+          workspace.store.setPollbookServiceForName(name, {
+            machineId: machineInformation.machineId,
+            apiClient,
+            lastSeen: new Date(),
+            status: PollbookConnectionStatus.Connected,
+          });
+        } catch (error) {
+          if (name === currentNodeServiceName) {
+            // Could not ping our own machine, mark as offline
+            debug('Failed to establish connection to self: %s', error);
+            debug('Setting online status to false');
+            workspace.store.setOnlineStatus(false);
+          }
+          debug(`Failed to establish connection from ${name}: ${error}`);
+        }
+      }
+      // Clean up stale machines
+      workspace.store.cleanupStalePollbookServices();
+    }
+  });
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -195,6 +195,18 @@ export const undoVoterCheckIn = {
   },
 } as const;
 
+export const resetNetwork = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.resetNetwork, {
+      async onSuccess() {
+        await queryClient.invalidateQueries(getDeviceStatuses.queryKey());
+      },
+    });
+  },
+} as const;
+
 export const registerVoter = {
   useMutation() {
     const apiClient = useApiClient();

--- a/frontend/src/nav_screen.tsx
+++ b/frontend/src/nav_screen.tsx
@@ -20,7 +20,7 @@ import type { UsbDriveStatus } from '@votingworks/usb-drive';
 import type { BatteryInfo } from '@votingworks/backend';
 import { format } from '@votingworks/utils';
 import { Row } from './layout';
-import { getDeviceStatuses } from './api';
+import { getDeviceStatuses, resetNetwork } from './api';
 import { PollbookConnectionStatus } from './types';
 
 export const DeviceInfoBar = styled(Row)`
@@ -44,6 +44,7 @@ export const Header = styled(MainHeader)`
 
 function NetworkStatus({ status }: { status: NetworkStatus }) {
   const [showModal, setShowModal] = useState(false);
+  const [isResetting, setIsResetting] = useState(false);
 
   const sortedPollbooks = [...status.pollbooks].sort((a, b) => {
     if (
@@ -73,6 +74,17 @@ function NetworkStatus({ status }: { status: NetworkStatus }) {
     return 0;
   });
 
+  const resetNetworkMutation = resetNetwork.useMutation();
+
+  function resetNetworkConnection() {
+    setIsResetting(true);
+    resetNetworkMutation.mutate(undefined, {
+      onSuccess: () => {
+        setIsResetting(false);
+      },
+    });
+  }
+
   return (
     <Row
       onClick={() => setShowModal(!showModal)}
@@ -83,6 +95,8 @@ function NetworkStatus({ status }: { status: NetworkStatus }) {
         status.pollbooks.filter(
           (pollbook) => pollbook.status === PollbookConnectionStatus.Connected
         ).length
+      ) : isResetting ? (
+        <Icons.Loading />
       ) : (
         <Icons.Warning color="inverseWarning" />
       )}
@@ -97,49 +111,72 @@ function NetworkStatus({ status }: { status: NetworkStatus }) {
                 boxShadow: '0 0.5rem 1rem rgba(0, 0, 0, 0.1)',
               }}
             >
-              {sortedPollbooks.length === 0 && <span>No pollbooks found</span>}
-              {sortedPollbooks.length > 0 && (
-                <Table>
-                  <thead>
-                    <tr>
-                      <th>Status</th>
-                      <th>Machine ID</th>
-                      <th>Last Seen</th>
-                      <th># Check-ins</th>
-                    </tr>
-                  </thead>
-                  {sortedPollbooks.map((pollbook) => (
-                    <tr
-                      key={pollbook.machineId}
-                      style={{ gap: '0.5rem', alignItems: 'center' }}
-                    >
-                      <td>
-                        {pollbook.status ===
-                          PollbookConnectionStatus.Connected && (
-                          <Icons.Checkmark color="primary" />
-                        )}
-                        {(pollbook.status ===
-                          PollbookConnectionStatus.LostConnection ||
-                          pollbook.status ===
-                            PollbookConnectionStatus.ShutDown) && (
-                          <Icons.Warning color="inverseWarning" />
-                        )}
-                        {pollbook.status ===
-                          PollbookConnectionStatus.WrongElection && (
-                          <Icons.X color="danger" />
-                        )}
-                      </td>
-                      <td>{pollbook.machineId}</td>
-                      <td>{new Date(pollbook.lastSeen).toLocaleString()}</td>
-                      <td>{pollbook.numCheckIns} check-ins</td>
-                    </tr>
-                  ))}
-                </Table>
+              {!status.isOnline && !isResetting && (
+                <div style={{ alignContent: 'center' }}>
+                  <p>Network is offline.</p>
+                </div>
               )}
+              {isResetting && (
+                <div>
+                  <Icons.Loading /> <br />{' '}
+                  <p>Resetting network connection...</p>
+                </div>
+              )}
+              {sortedPollbooks.length === 0 && status.isOnline && (
+                <span>No pollbooks found</span>
+              )}
+              {status.isOnline &&
+                !isResetting &&
+                sortedPollbooks.length > 0 && (
+                  <Table>
+                    <thead>
+                      <tr>
+                        <th>Status</th>
+                        <th>Machine ID</th>
+                        <th>Last Seen</th>
+                        <th># Check-ins</th>
+                      </tr>
+                    </thead>
+                    {sortedPollbooks.map((pollbook) => (
+                      <tr
+                        key={pollbook.machineId}
+                        style={{ gap: '0.5rem', alignItems: 'center' }}
+                      >
+                        <td>
+                          {pollbook.status ===
+                            PollbookConnectionStatus.Connected && (
+                            <Icons.Checkmark color="primary" />
+                          )}
+                          {(pollbook.status ===
+                            PollbookConnectionStatus.LostConnection ||
+                            pollbook.status ===
+                              PollbookConnectionStatus.ShutDown) && (
+                            <Icons.Warning color="inverseWarning" />
+                          )}
+                          {pollbook.status ===
+                            PollbookConnectionStatus.WrongElection && (
+                            <Icons.X color="danger" />
+                          )}
+                        </td>
+                        <td>{pollbook.machineId}</td>
+                        <td>{new Date(pollbook.lastSeen).toLocaleString()}</td>
+                        <td>{pollbook.numCheckIns} check-ins</td>
+                      </tr>
+                    ))}
+                  </Table>
+                )}
             </div>
           }
-          onOverlayClick={() => setShowModal(false)}
-          actions={<Button onPress={() => setShowModal(false)}>Close</Button>}
+          actions={
+            <React.Fragment>
+              {status.isOnline ? null : (
+                <Button onPress={resetNetworkConnection} color="primary">
+                  Reset Network
+                </Button>
+              )}
+              <Button onPress={() => setShowModal(false)}>Close</Button>
+            </React.Fragment>
+          }
         />
       )}
     </Row>

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -60,6 +60,7 @@ import {
   faImage,
   faTowerBroadcast,
   faPrint,
+  faRotate,
 } from '@fortawesome/free-solid-svg-icons';
 import {
   faXmarkCircle,
@@ -366,6 +367,10 @@ export const Icons = {
 
   Question(props) {
     return <FaIcon {...props} type={faCircleQuestion} />;
+  },
+
+  Rotate(props) {
+    return <FaIcon {...props} type={faRotate} />;
   },
 
   RotateRight(props) {

--- a/script/setup_basic_mesh.sh
+++ b/script/setup_basic_mesh.sh
@@ -5,14 +5,10 @@
 
 # Check if mesh0 interface already exists
 if iw dev | grep -q "mesh0"; then
-    force=false
-    if [[ " $@ " == *" --force "* ]]; then
-        force=true
-    fi
     mesh_type=$(iw dev mesh0 info 2>/dev/null | grep "type" | awk '{print $2" "$3}')
-    if [ "$force" = true ] || [ "$mesh_type" != "mesh point" ]; then
+    if [ "$mesh_type" != "mesh point" ]; then
         echo "Deleting existing interface mesh0 due to mismatched type or --force flag."
-        sudo ip link delete mesh0
+        sudo iw dev mesh0 del
         sleep 1
     else
         mesh_status=$(ip link show mesh0 | grep -o "state [A-Z]*" | awk '{print $2}')

--- a/script/setup_basic_mesh.sh
+++ b/script/setup_basic_mesh.sh
@@ -5,24 +5,9 @@
 
 # Check if mesh0 interface already exists
 if iw dev | grep -q "mesh0"; then
-    mesh_type=$(iw dev mesh0 info 2>/dev/null | grep "type" | awk '{print $2" "$3}')
-    if [ "$mesh_type" != "mesh point" ]; then
-        echo "Deleting existing interface mesh0 due to mismatched type or --force flag."
-        sudo iw dev mesh0 del
-        sleep 1
-    else
-        mesh_status=$(ip link show mesh0 | grep -o "state [A-Z]*" | awk '{print $2}')
-        if [ "$mesh_status" = "DOWN" ]; then
-            echo "mesh0 is DOWN. Bringing it up..."
-            sudo ip link set mesh0 up
-            echo "Successfully brought up the interface."
-            exit 0
-        fi
-        echo "mesh0 already exists. Joining pollbook_mesh."
-        sudo iw dev mesh0 mesh join pollbook_mesh
-        echo "Successfully joined the network."
-        exit 0
-    fi
+    echo "Deleting existing interface mesh0 due to mismatched type or --force flag."
+    sudo iw dev mesh0 del
+    sleep 1
 fi
 
 wireless_interface=$(iw dev | awk '/Interface/ {print $2}' | grep -v "wlp9s0")


### PR DESCRIPTION
Updates the setup_basic_mesh.sh script that is run on boot/sleep awakening/etc. to just delete the mesh0 interface if it already exists as a first step. This seems to work more reliably then trying to bring it back up if it gets in any number of broken states. Also adds a UI option (somewhat ugly for now) to force this script to be run to reset the network. Along with some refactoring / new debugging lines / etc. in the networking code. 