### PR TITLE
Always show reset button, timeout after 10s

### DIFF
--- a/backend/src/globals.ts
+++ b/backend/src/globals.ts
@@ -32,7 +32,7 @@ export const WORKSPACE =
     : undefined);
 
 export const NETWORK_POLLING_INTERVAL = 5000;
-export const MACHINE_DISCONNECTED_TIMEOUT = 60000;
+export const MACHINE_DISCONNECTED_TIMEOUT = 10000;
 export const NETWORK_REQUEST_TIMEOUT = 1000;
 
 export const NETWORK_EVENT_LIMIT = 500;

--- a/frontend/src/nav_screen.tsx
+++ b/frontend/src/nav_screen.tsx
@@ -169,11 +169,9 @@ function NetworkStatus({ status }: { status: NetworkStatus }) {
           }
           actions={
             <React.Fragment>
-              {status.isOnline ? null : (
-                <Button onPress={resetNetworkConnection} color="primary">
-                  Reset Network
-                </Button>
-              )}
+              <Button onPress={resetNetworkConnection} color="primary">
+                Reset Network
+              </Button>
               <Button onPress={() => setShowModal(false)}>Close</Button>
             </React.Fragment>
           }


### PR DESCRIPTION
Always expose network reset option, and update timeout for other pollbooks to 10seconds before showing as not connected. 