### PR TITLE
Remove CVA voter identification method

### DIFF
--- a/backend/src/check_in_receipt.tsx
+++ b/backend/src/check_in_receipt.tsx
@@ -10,8 +10,6 @@ function prettyIdentificationMethod(
   switch (identificationMethod.type) {
     case 'photoId':
       return `Photo ID (${identificationMethod.state})`;
-    case 'challengedVoterAffidavit':
-      return 'CVA';
     case 'personalRecognizance':
       switch (identificationMethod.recognizer) {
         case 'supervisor':

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -65,9 +65,6 @@ export type VoterIdentificationMethod =
       state: string;
     }
   | {
-      type: 'challengedVoterAffidavit';
-    }
-  | {
       type: 'personalRecognizance';
       recognizer: 'supervisor' | 'moderator' | 'cityClerk';
     };
@@ -84,9 +81,6 @@ export const VoterCheckInSchema: z.ZodSchema<VoterCheckIn> = z.object({
     z.object({
       type: z.literal('photoId'),
       state: z.string(),
-    }),
-    z.object({
-      type: z.literal('challengedVoterAffidavit'),
     }),
     z.object({
       type: z.literal('personalRecognizance'),

--- a/backend/src/voter_checklist.tsx
+++ b/backend/src/voter_checklist.tsx
@@ -112,7 +112,6 @@ export function VoterChecklistTable({
           <th />
           <th>Party</th>
           <th>Voter Name</th>
-          <th>CVA</th>
           <th>OOS&nbsp;DL</th>
           <th>PR</th>
           <th>Domicile Address</th>
@@ -141,12 +140,6 @@ export function VoterChecklistTable({
                 {voter.lastName}
               </span>
               , {voter.suffix} {voter.firstName} {voter.middleName}
-            </td>
-            <td>
-              {voter.checkIn?.identificationMethod.type ===
-              'challengedVoterAffidavit'
-                ? '☑'
-                : '☐'}
             </td>
             <td>
               {voter.checkIn?.identificationMethod.type === 'photoId' &&

--- a/frontend/src/voter_confirm_screen.tsx
+++ b/frontend/src/voter_confirm_screen.tsx
@@ -32,8 +32,6 @@ function isIdentificationMethodComplete(
   switch (identificationMethod.type) {
     case 'photoId':
       return Boolean(identificationMethod.state);
-    case 'challengedVoterAffidavit':
-      return true;
     case 'personalRecognizance':
       return Boolean(identificationMethod.recognizer);
     case undefined:
@@ -87,40 +85,29 @@ export function VoterConfirmScreen({
                     setIdentificationMethod({ type: value, state: 'NH' })
                   }
                 />
-                {identificationMethod.type === 'photoId' && (
-                  <Row style={{ gap: '0.5rem', alignItems: 'center' }}>
-                    <label htmlFor="state">Select state:</label>
-                    <SearchSelect
-                      id="state"
-                      style={{ flex: 1 }}
-                      options={Object.entries(usStates).map(
-                        ([value, label]) => ({
-                          value,
-                          label: `${value} - ${label}`,
-                        })
-                      )}
-                      value={
-                        identificationMethod.type === 'photoId'
-                          ? identificationMethod.state
-                          : undefined
-                      }
-                      onChange={(state) =>
-                        setIdentificationMethod({
-                          type: 'photoId',
-                          state,
-                        })
-                      }
-                    />
-                  </Row>
-                )}
-                <RadioOption
-                  label="Challenged Voter Affidavit (CVA)"
-                  value="challengedVoterAffidavit"
-                  isSelected={
-                    identificationMethod.type === 'challengedVoterAffidavit'
-                  }
-                  onChange={(value) => setIdentificationMethod({ type: value })}
-                />
+                <Row style={{ gap: '0.5rem', alignItems: 'center' }}>
+                  <label htmlFor="state">Select state:</label>
+                  <SearchSelect
+                    id="state"
+                    style={{ flex: 1 }}
+                    options={Object.entries(usStates).map(([value, label]) => ({
+                      value,
+                      label: `${value} - ${label}`,
+                    }))}
+                    value={
+                      identificationMethod.type === 'photoId'
+                        ? identificationMethod.state
+                        : undefined
+                    }
+                    onChange={(state) =>
+                      setIdentificationMethod({
+                        type: 'photoId',
+                        state,
+                      })
+                    }
+                    disabled={identificationMethod.type !== 'photoId'}
+                  />
+                </Row>
                 <RadioOption
                   label="Personal Recognizance"
                   value="personalRecognizance"
@@ -129,37 +116,38 @@ export function VoterConfirmScreen({
                   }
                   onChange={(value) => setIdentificationMethod({ type: value })}
                 />
-                {identificationMethod.type === 'personalRecognizance' && (
-                  <Row style={{ gap: '0.5rem', alignItems: 'center' }}>
-                    <label htmlFor="recognizer">Select recognizer:</label>
-                    <SearchSelect
-                      id="recognizer"
-                      style={{ flex: 1 }}
-                      options={[
-                        {
-                          label: 'Supervisor',
-                          value: 'supervisor',
-                        },
-                        {
-                          label: 'Moderator',
-                          value: 'moderator',
-                        },
-                        { label: 'City Clerk', value: 'cityClerk' },
-                      ]}
-                      value={
-                        identificationMethod.type === 'personalRecognizance'
-                          ? identificationMethod.recognizer
-                          : undefined
-                      }
-                      onChange={(value) => {
-                        setIdentificationMethod({
-                          type: 'personalRecognizance',
-                          recognizer: value,
-                        });
-                      }}
-                    />
-                  </Row>
-                )}
+                <Row style={{ gap: '0.5rem', alignItems: 'center' }}>
+                  <label htmlFor="recognizer">Select recognizer:</label>
+                  <SearchSelect
+                    id="recognizer"
+                    style={{ flex: 1 }}
+                    options={[
+                      {
+                        label: 'Supervisor',
+                        value: 'supervisor',
+                      },
+                      {
+                        label: 'Moderator',
+                        value: 'moderator',
+                      },
+                      { label: 'City Clerk', value: 'cityClerk' },
+                    ]}
+                    value={
+                      identificationMethod.type === 'personalRecognizance'
+                        ? identificationMethod.recognizer
+                        : undefined
+                    }
+                    onChange={(value) => {
+                      setIdentificationMethod({
+                        type: 'personalRecognizance',
+                        recognizer: value,
+                      });
+                    }}
+                    disabled={
+                      identificationMethod.type !== 'personalRecognizance'
+                    }
+                  />
+                </Row>
               </fieldset>
             </Column>
           )}


### PR DESCRIPTION
Closes #78 

Removes CVA as an identification method option.

Also changes the confirm check-in screen to always show form elements for photo ID/personal recognizance to avoid having things jump around when you switch methods.

https://github.com/user-attachments/assets/1fe7dcbb-80eb-4379-bd59-3126729975be

