### PR TITLE
Add field to record initials for personal recognizance 

### DIFF
--- a/backend/src/check_in_receipt.tsx
+++ b/backend/src/check_in_receipt.tsx
@@ -11,7 +11,7 @@ function prettyIdentificationMethod(
     case 'photoId':
       return `Photo ID (${identificationMethod.state})`;
     case 'personalRecognizance':
-      switch (identificationMethod.recognizer) {
+      switch (identificationMethod.recognizerType) {
         case 'supervisor':
           return 'PR (Supervisor)';
         case 'moderator':
@@ -19,7 +19,7 @@ function prettyIdentificationMethod(
         case 'cityClerk':
           return 'PR (City Clerk)';
         default:
-          return throwIllegalValue(identificationMethod.recognizer);
+          return throwIllegalValue(identificationMethod.recognizerType);
       }
     default:
       throwIllegalValue(identificationMethod);

--- a/backend/src/store_multi_node.test.ts
+++ b/backend/src/store_multi_node.test.ts
@@ -359,7 +359,7 @@ test('last write wins on double check ins', async () => {
     voterId: 'bob',
     identificationMethod: {
       type: 'personalRecognizance',
-      recognizer: 'supervisor',
+      recognizerType: 'supervisor',
     },
   });
   expect(pollbookB.getCheckInCount()).toEqual(1);
@@ -438,7 +438,7 @@ test('last write wins even when there is bad system time after a sync', () => {
     voterId: 'bob',
     identificationMethod: {
       type: 'personalRecognizance',
-      recognizer: 'supervisor',
+      recognizerType: 'supervisor',
     },
   });
   expect(pollbookA.getCheckInCount()).toEqual(1);

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -66,7 +66,8 @@ export type VoterIdentificationMethod =
     }
   | {
       type: 'personalRecognizance';
-      recognizer: 'supervisor' | 'moderator' | 'cityClerk';
+      recognizerType: 'supervisor' | 'moderator' | 'cityClerk';
+      recognizerInitials: string;
     };
 
 export interface VoterCheckIn {
@@ -84,11 +85,12 @@ export const VoterCheckInSchema: z.ZodSchema<VoterCheckIn> = z.object({
     }),
     z.object({
       type: z.literal('personalRecognizance'),
-      recognizer: z.union([
+      recognizerType: z.union([
         z.literal('supervisor'),
         z.literal('moderator'),
         z.literal('cityClerk'),
       ]),
+      recognizerInitials: z.string(),
     }),
   ]),
   isAbsentee: z.boolean(),

--- a/backend/src/voter_checklist.tsx
+++ b/backend/src/voter_checklist.tsx
@@ -113,7 +113,6 @@ export function VoterChecklistTable({
           <th>Party</th>
           <th>Voter Name</th>
           <th>OOS&nbsp;DL</th>
-          <th>PR</th>
           <th>Domicile Address</th>
           <th>Mailing Address</th>
           <th>Dist</th>
@@ -127,6 +126,20 @@ export function VoterChecklistTable({
             <td>
               {voter.checkIn?.isAbsentee && (
                 <span style={{ color: redTextColor }}>A.V.</span>
+              )}
+              {voter.checkIn?.identificationMethod.type ===
+                'personalRecognizance' && (
+                <span style={{ color: redTextColor }}>
+                  P-
+                  {
+                    {
+                      supervisor: 'S',
+                      moderator: 'M',
+                      cityClerk: 'C',
+                    }[voter.checkIn.identificationMethod.recognizerType]
+                  }
+                  -{voter.checkIn.identificationMethod.recognizerInitials}
+                </span>
               )}
             </td>
             <td>{voter.checkIn ? '☑' : '☐'}</td>
@@ -149,22 +162,6 @@ export function VoterChecklistTable({
                     {voter.checkIn.identificationMethod.state}
                   </span>
                 </u>
-              ) : (
-                '__'
-              )}
-            </td>
-            <td>
-              {voter.checkIn?.identificationMethod.type ===
-              'personalRecognizance' ? (
-                <span style={{ color: redTextColor }}>
-                  {
-                    {
-                      supervisor: 'S',
-                      moderator: 'M',
-                      cityClerk: 'C',
-                    }[voter.checkIn.identificationMethod.recognizerType]
-                  }
-                </span>
               ) : (
                 '__'
               )}

--- a/backend/src/voter_checklist.tsx
+++ b/backend/src/voter_checklist.tsx
@@ -162,7 +162,7 @@ export function VoterChecklistTable({
                       supervisor: 'S',
                       moderator: 'M',
                       cityClerk: 'C',
-                    }[voter.checkIn.identificationMethod.recognizer]
+                    }[voter.checkIn.identificationMethod.recognizerType]
                   }
                 </span>
               ) : (

--- a/frontend/src/voter_confirm_screen.tsx
+++ b/frontend/src/voter_confirm_screen.tsx
@@ -33,7 +33,10 @@ function isIdentificationMethodComplete(
     case 'photoId':
       return Boolean(identificationMethod.state);
     case 'personalRecognizance':
-      return Boolean(identificationMethod.recognizer);
+      return (
+        Boolean(identificationMethod.recognizerType) &&
+        identificationMethod.recognizerInitials?.length === 2
+      );
     case undefined:
       return false;
     default:
@@ -77,77 +80,112 @@ export function VoterConfirmScreen({
                 }}
                 role="radiogroup"
               >
-                <RadioOption
-                  label="Photo ID"
-                  value="photoId"
-                  isSelected={identificationMethod.type === 'photoId'}
-                  onChange={(value) =>
-                    setIdentificationMethod({ type: value, state: 'NH' })
-                  }
-                />
-                <Row style={{ gap: '0.5rem', alignItems: 'center' }}>
-                  <label htmlFor="state">Select state:</label>
-                  <SearchSelect
-                    id="state"
-                    style={{ flex: 1 }}
-                    options={Object.entries(usStates).map(([value, label]) => ({
-                      value,
-                      label: `${value} - ${label}`,
-                    }))}
-                    value={
-                      identificationMethod.type === 'photoId'
-                        ? identificationMethod.state
-                        : undefined
-                    }
-                    onChange={(state) =>
-                      setIdentificationMethod({
-                        type: 'photoId',
-                        state,
-                      })
-                    }
-                    disabled={identificationMethod.type !== 'photoId'}
-                  />
-                </Row>
-                <RadioOption
-                  label="Personal Recognizance"
-                  value="personalRecognizance"
-                  isSelected={
-                    identificationMethod.type === 'personalRecognizance'
-                  }
-                  onChange={(value) => setIdentificationMethod({ type: value })}
-                />
-                <Row style={{ gap: '0.5rem', alignItems: 'center' }}>
-                  <label htmlFor="recognizer">Select recognizer:</label>
-                  <SearchSelect
-                    id="recognizer"
-                    style={{ flex: 1 }}
-                    options={[
-                      {
-                        label: 'Supervisor',
-                        value: 'supervisor',
-                      },
-                      {
-                        label: 'Moderator',
-                        value: 'moderator',
-                      },
-                      { label: 'City Clerk', value: 'cityClerk' },
-                    ]}
-                    value={
-                      identificationMethod.type === 'personalRecognizance'
-                        ? identificationMethod.recognizer
-                        : undefined
-                    }
-                    onChange={(value) => {
-                      setIdentificationMethod({
-                        type: 'personalRecognizance',
-                        recognizer: value,
-                      });
-                    }}
-                    disabled={
-                      identificationMethod.type !== 'personalRecognizance'
-                    }
-                  />
-                </Row>
+                <Card color="neutral">
+                  <Column style={{ gap: '0.5rem' }}>
+                    <RadioOption
+                      label="Photo ID"
+                      value="photoId"
+                      isSelected={identificationMethod.type === 'photoId'}
+                      onChange={(value) =>
+                        setIdentificationMethod({ type: value, state: 'NH' })
+                      }
+                    />
+                    <Row style={{ gap: '0.5rem', alignItems: 'center' }}>
+                      <label htmlFor="state">ID State:</label>
+                      <SearchSelect
+                        id="state"
+                        style={{ flex: 1 }}
+                        options={Object.entries(usStates).map(
+                          ([value, label]) => ({
+                            value,
+                            label: `${value} - ${label}`,
+                          })
+                        )}
+                        value={
+                          identificationMethod.type === 'photoId'
+                            ? identificationMethod.state
+                            : undefined
+                        }
+                        onChange={(state) =>
+                          setIdentificationMethod({
+                            type: 'photoId',
+                            state,
+                          })
+                        }
+                        disabled={identificationMethod.type !== 'photoId'}
+                      />
+                    </Row>
+                  </Column>
+                </Card>
+                <Card color="neutral">
+                  <Column style={{ gap: '0.5rem' }}>
+                    <RadioOption
+                      label="Personal Recognizance"
+                      value="personalRecognizance"
+                      isSelected={
+                        identificationMethod.type === 'personalRecognizance'
+                      }
+                      onChange={(value) =>
+                        setIdentificationMethod({ type: value })
+                      }
+                    />
+                    <Row style={{ gap: '0.5rem', alignItems: 'center' }}>
+                      <label htmlFor="recognizer">Recognizer:</label>
+                      <SearchSelect
+                        id="recognizer"
+                        style={{ flex: 1 }}
+                        options={[
+                          {
+                            label: 'Supervisor',
+                            value: 'supervisor',
+                          },
+                          {
+                            label: 'Moderator',
+                            value: 'moderator',
+                          },
+                          { label: 'City Clerk', value: 'cityClerk' },
+                        ]}
+                        value={
+                          identificationMethod.type === 'personalRecognizance'
+                            ? identificationMethod.recognizerType
+                            : undefined
+                        }
+                        onChange={(value) => {
+                          setIdentificationMethod({
+                            ...identificationMethod,
+                            recognizerType: value,
+                          });
+                        }}
+                        disabled={
+                          identificationMethod.type !== 'personalRecognizance'
+                        }
+                      />
+                      <label htmlFor="initals">Recognizer Initials:</label>
+                      <input
+                        id="initials"
+                        type="text"
+                        value={
+                          identificationMethod.type === 'personalRecognizance'
+                            ? identificationMethod.recognizerInitials
+                            : undefined
+                        }
+                        onChange={(event) => {
+                          setIdentificationMethod({
+                            ...identificationMethod,
+                            recognizerInitials:
+                              event.target.value.toLocaleUpperCase(),
+                          });
+                        }}
+                        disabled={
+                          identificationMethod.type !== 'personalRecognizance'
+                        }
+                        style={{ width: '3rem' }}
+                        minLength={2}
+                        maxLength={2}
+                      />
+                    </Row>
+                  </Column>
+                </Card>
               </fieldset>
             </Column>
           )}


### PR DESCRIPTION
Closes #79 , closes #95 

Adds a field to the check-in flow to record the initials of the recognizer for the personal recognizance identification method. Also puts these initials in the backup voter checklist (and moves them to the initial column of the checklist).


https://github.com/user-attachments/assets/5ffcf718-865f-4392-aa9d-8798d657515e


<img width="876" alt="Screenshot 2025-02-10 at 2 53 09 PM" src="https://github.com/user-attachments/assets/d44957ac-b875-451e-8774-a7d7ccc37bad" />
