### PR TITLE
Split backup voter checklist into two PDFs for printing 

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -50,6 +50,7 @@
     "fs-extra": "11.1.1",
     "jsbarcode": "^3.11.6",
     "node-fetch": "^2.6.0",
+    "pdf-lib": "^1.17.1",
     "react": "18.3.1",
     "styled-components": "^5.3.11",
     "uuid": "9.0.1",

--- a/backend/src/backup_worker.ts
+++ b/backend/src/backup_worker.ts
@@ -11,10 +11,28 @@ import { setInterval } from 'node:timers/promises';
 import { renderToPdf } from '@votingworks/printing';
 import { UsbDrive } from '@votingworks/usb-drive';
 import { cp } from 'node:fs/promises';
+import { iter, range } from '@votingworks/basics';
+import { PDFDocument } from 'pdf-lib';
+import { Buffer } from 'node:buffer';
 import { Workspace } from './types';
 import { VoterChecklist, VoterChecklistHeader } from './voter_checklist';
 
 const BACKUP_INTERVAL = 1_000 * 60; // 1 minute
+
+export async function concatenatePdfs(pdfs: Buffer[]): Promise<Buffer> {
+  const combinedPdf = await PDFDocument.create();
+  for (const pdf of pdfs) {
+    const pdfDoc = await PDFDocument.load(pdf);
+    const copiedPages = await combinedPdf.copyPages(
+      pdfDoc,
+      pdfDoc.getPageIndices()
+    );
+    for (const page of copiedPages) {
+      combinedPdf.addPage(page);
+    }
+  }
+  return Buffer.from(await combinedPdf.save());
+}
 
 /**
  * Save a file to disk.
@@ -67,45 +85,63 @@ async function exportBackupVoterChecklist(
   }
   console.log('Exporting backup voter checklist');
   console.time('Exported backup voter checklist');
-  const headerElement = React.createElement(VoterChecklistHeader, {
-    totalCheckIns: workspace.store.getCheckInCount(),
-  });
-  const tableElement = React.createElement(VoterChecklist, {
-    voterGroups: workspace.store.groupVotersAlphabeticallyByLastName(),
-  });
-  const workspaceBackupPath = join(
-    workspace.assetDirectoryPath,
-    'backup_voter_checklist.pdf'
-  );
-  const pdf = (
-    await renderToPdf({
-      headerTemplate: headerElement,
-      document: tableElement,
-      landscape: true,
-      marginDimensions: {
-        top: 0.7, // Leave space for header
-        right: 0.25,
-        bottom: 0.25,
-        left: 0.25,
-      },
-    })
-  ).unsafeUnwrap();
-  (await exportFile({ path: workspaceBackupPath, data: pdf })).unsafeUnwrap();
+  const voterGroups = workspace.store.groupVotersAlphabeticallyByLastName();
+  const groupPdfs = iter(voterGroups)
+    .async()
+    .map(async (voterGroup) => {
+      const headerElement = React.createElement(VoterChecklistHeader, {
+        totalCheckIns: workspace.store.getCheckInCount(),
+        voterGroup,
+      });
+      const tableElement = React.createElement(VoterChecklist, {
+        voterGroup,
+      });
+      return (
+        await renderToPdf({
+          headerTemplate: headerElement,
+          document: tableElement,
+          landscape: true,
+          marginDimensions: {
+            top: 0.7, // Leave space for header
+            right: 0.25,
+            bottom: 0.25,
+            left: 0.25,
+          },
+        })
+      ).unsafeUnwrap();
+    });
+
+  const numPdfChunks = 2;
+  const chunkLength = Math.ceil(voterGroups.length / numPdfChunks);
+  for await (const [i, pdfs] of groupPdfs.chunks(chunkLength).enumerate()) {
+    const workspaceBackupPath = join(
+      workspace.assetDirectoryPath,
+      `backup_voter_checklist_part_${i + 1}.pdf`
+    );
+    const pdf = await concatenatePdfs(pdfs);
+    (await exportFile({ path: workspaceBackupPath, data: pdf })).unsafeUnwrap();
+  }
   console.timeEnd('Exported backup voter checklist');
 
   usbDriveStatus = await usbDrive.status();
   if (usbDriveStatus.status === 'mounted') {
     console.time('Copied backup voter checklist to USB drive');
-    const usbBackupPath = join(
-      usbDriveStatus.mountPoint,
-      'backup_voter_checklist.pdf'
-    );
-    const usbInProgressPath = join(
-      usbDriveStatus.mountPoint,
-      'backup_voter_checklist.in_progress.pdf'
-    );
-    await cp(workspaceBackupPath, usbInProgressPath);
-    await move(usbInProgressPath, usbBackupPath, { overwrite: true });
+    for (const i of range(1, numPdfChunks + 1)) {
+      const workspaceBackupPath = join(
+        workspace.assetDirectoryPath,
+        `backup_voter_checklist_part_${i}.pdf`
+      );
+      const usbBackupPath = join(
+        usbDriveStatus.mountPoint,
+        `backup_voter_checklist_part_${i}.pdf`
+      );
+      const usbInProgressPath = join(
+        usbDriveStatus.mountPoint,
+        `backup_voter_checklist_part_${i}.in_progress.pdf`
+      );
+      await cp(workspaceBackupPath, usbInProgressPath);
+      await move(usbInProgressPath, usbBackupPath, { overwrite: true });
+    }
     await usbDrive.sync();
     console.timeEnd('Copied backup voter checklist to USB drive');
   } else {

--- a/backend/src/backup_worker.ts
+++ b/backend/src/backup_worker.ts
@@ -86,11 +86,12 @@ async function exportBackupVoterChecklist(
   console.log('Exporting backup voter checklist');
   console.time('Exported backup voter checklist');
   const voterGroups = workspace.store.groupVotersAlphabeticallyByLastName();
+  const totalCheckIns = workspace.store.getCheckInCount();
   const groupPdfs = iter(voterGroups)
     .async()
     .map(async (voterGroup) => {
       const headerElement = React.createElement(VoterChecklistHeader, {
-        totalCheckIns: workspace.store.getCheckInCount(),
+        totalCheckIns,
         voterGroup,
       });
       const tableElement = React.createElement(VoterChecklist, {
@@ -111,6 +112,9 @@ async function exportBackupVoterChecklist(
       ).unsafeUnwrap();
     });
 
+  // For now, split into two PDFs so users can parallelize printing. In the
+  // future we may want to decide this dynamically based on the number of
+  // voters.
   const numPdfChunks = 2;
   const chunkLength = Math.ceil(voterGroups.length / numPdfChunks);
   for await (const [i, pdfs] of groupPdfs.chunks(chunkLength).enumerate()) {

--- a/backend/src/store_multi_node.test.ts
+++ b/backend/src/store_multi_node.test.ts
@@ -360,6 +360,7 @@ test('last write wins on double check ins', async () => {
     identificationMethod: {
       type: 'personalRecognizance',
       recognizerType: 'supervisor',
+      recognizerInitials: 'AB',
     },
   });
   expect(pollbookB.getCheckInCount()).toEqual(1);
@@ -439,6 +440,7 @@ test('last write wins even when there is bad system time after a sync', () => {
     identificationMethod: {
       type: 'personalRecognizance',
       recognizerType: 'supervisor',
+      recognizerInitials: 'AB',
     },
   });
   expect(pollbookA.getCheckInCount()).toEqual(1);

--- a/backend/src/voter_checklist.tsx
+++ b/backend/src/voter_checklist.tsx
@@ -51,13 +51,16 @@ const StyledVoterChecklistHeader = styled.div`
 
 export function VoterChecklistHeader({
   totalCheckIns,
+  voterGroup,
 }: {
   totalCheckIns: number;
+  voterGroup: VoterGroup;
 }): JSX.Element {
+  const letter = voterGroup.existingVoters[0].lastName[0].toLocaleUpperCase();
   return (
     <StyledVoterChecklistHeader>
       <div>
-        <h1>Backup Voter Checklist</h1>
+        <h1>Backup Voter Checklist: {letter}</h1>
         <h2>Sample Election &bull; Sample Town</h2>
       </div>
       <div
@@ -275,7 +278,6 @@ export function NewRegistrationsVoterChecklistTable({
             <td />
             <td />
             <td />
-            <td />
           </tr>
         ))}
       </tbody>
@@ -284,24 +286,16 @@ export function NewRegistrationsVoterChecklistTable({
 }
 
 export function VoterChecklist({
-  voterGroups,
+  voterGroup,
 }: {
-  voterGroups: VoterGroup[];
+  voterGroup: VoterGroup;
 }): JSX.Element {
   return (
-    <>
-      {voterGroups.map((voterGroup, index) => (
-        <React.Fragment key={index}>
-          <VoterChecklistTable
-            key={`existing-${index}`}
-            voters={voterGroup.existingVoters}
-          />
-          <NewRegistrationsVoterChecklistTable
-            key={`new-${index}`}
-            voters={voterGroup.newRegistrations}
-          />
-        </React.Fragment>
-      ))}
-    </>
+    <React.Fragment>
+      <VoterChecklistTable voters={voterGroup.existingVoters} />
+      <NewRegistrationsVoterChecklistTable
+        voters={voterGroup.newRegistrations}
+      />
+    </React.Fragment>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   '@babel/traverse': 7.23.2
   '@types/eslint': 8.4.1
@@ -113,6 +117,9 @@ importers:
       node-fetch:
         specifier: ^2.6.0
         version: 2.7.0
+      pdf-lib:
+        specifier: ^1.17.1
+        version: 1.17.1
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -375,7 +382,7 @@ importers:
         version: 0.2.3
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.3)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
       vite:
         specifier: 4.5.2
         version: 4.5.2(@types/node@20.16.0)
@@ -513,7 +520,7 @@ importers:
         version: 1.57.0
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
+        version: 2.1.8
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -1319,7 +1326,7 @@ importers:
         version: 2.2.2(jest@29.7.0)
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.3)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
 
   libs/grout:
     dependencies:
@@ -1371,7 +1378,7 @@ importers:
         version: 1.57.0
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
+        version: 2.1.8
 
   libs/grout/test-utils:
     dependencies:
@@ -1402,7 +1409,7 @@ importers:
         version: 1.57.0
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
+        version: 2.1.8
 
   libs/image-utils:
     dependencies:
@@ -1755,7 +1762,7 @@ importers:
         version: 1.57.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.3)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
 
   libs/test-utils:
     dependencies:
@@ -1916,7 +1923,7 @@ importers:
         version: 1.57.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.3)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
 
   libs/ui:
     dependencies:
@@ -2193,7 +2200,7 @@ importers:
         version: 0.2.3
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.3)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
       util:
         specifier: ^0.12.4
         version: 0.12.5
@@ -2266,7 +2273,7 @@ importers:
         version: 1.57.0
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.26.0)(@jest/types@29.6.3)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
+        version: 29.1.1(@babel/core@7.26.0)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2)
 
   libs/utils:
     dependencies:
@@ -5182,6 +5189,18 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
+  /@pdf-lib/standard-fonts@1.0.0:
+    resolution: {integrity: sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==}
+    dependencies:
+      pako: 1.0.11
+    dev: false
+
+  /@pdf-lib/upng@1.0.1:
+    resolution: {integrity: sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==}
+    dependencies:
+      pako: 1.0.11
+    dev: false
+
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -5714,7 +5733,7 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-      typescript: '*'
+      typescript: 5.6.2
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -6700,7 +6719,7 @@ packages:
       magicast: 0.3.5
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
+      vitest: 2.1.8
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8471,7 +8490,7 @@ packages:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
     peerDependencies:
-      typescript: '>=4.9.5'
+      typescript: 5.6.2
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -9714,7 +9733,7 @@ packages:
     resolution: {integrity: sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      '@types/eslint': '>=8.0.0'
+      '@types/eslint': 8.4.1
       eslint: '>=8.0.0'
       eslint-config-prettier: '*'
       prettier: '>=3.0.0'
@@ -13796,6 +13815,15 @@ packages:
       nan: 2.22.0
     dev: false
 
+  /pdf-lib@1.17.1:
+    resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
+    dependencies:
+      '@pdf-lib/standard-fonts': 1.0.0
+      '@pdf-lib/upng': 1.0.1
+      pako: 1.0.11
+      tslib: 1.14.1
+    dev: false
+
   /pdfjs-dist@2.3.200(webpack@4.47.0):
     resolution: {integrity: sha512-+8wBjU5h8LPZOIvR9X2uCrp/8xWQG1DRDKMLg5lzGN1qyIAZlYUxA0KQyy12Nw5jN7ozulC6v97PMaDcLgAcFg==}
     peerDependencies:
@@ -16144,7 +16172,7 @@ packages:
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
     engines: {node: '>=16'}
     peerDependencies:
-      typescript: '>=4.2.0'
+      typescript: 5.6.2
     dependencies:
       typescript: 5.6.2
 
@@ -16163,7 +16191,7 @@ packages:
       babel-jest: ^29.0.0
       esbuild: '*'
       jest: ^29.0.0
-      typescript: '>=4.3 <6'
+      typescript: 5.6.2
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -16176,6 +16204,41 @@ packages:
     dependencies:
       '@babel/core': 7.26.0
       '@jest/types': 29.6.3
+      bs-logger: 0.2.6
+      esbuild: 0.21.2
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@20.16.0)
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.6.3
+      typescript: 5.6.2
+      yargs-parser: 21.1.1
+    dev: true
+
+  /ts-jest@29.1.1(@babel/core@7.26.0)(esbuild@0.21.2)(jest@29.7.0)(typescript@5.6.2):
+    resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/types': ^29.0.0
+      babel-jest: ^29.0.0
+      esbuild: '*'
+      jest: ^29.0.0
+      typescript: 5.6.2
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@babel/core': 7.26.0
       bs-logger: 0.2.6
       esbuild: 0.21.2
       fast-json-stable-stringify: 2.1.0
@@ -16210,7 +16273,7 @@ packages:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+      typescript: 5.6.2
     dependencies:
       tslib: 1.14.1
       typescript: 5.6.2
@@ -16774,6 +16837,63 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /vitest@2.1.8:
+    resolution: {integrity: sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.8
+      '@vitest/ui': 2.1.8
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@vitest/expect': 2.1.8
+      '@vitest/mocker': 2.1.8(vite@5.4.11)
+      '@vitest/pretty-format': 2.1.8
+      '@vitest/runner': 2.1.8
+      '@vitest/snapshot': 2.1.8
+      '@vitest/spy': 2.1.8
+      '@vitest/utils': 2.1.8
+      chai: 5.1.2
+      debug: 4.4.0
+      expect-type: 1.1.0
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      std-env: 3.8.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.1
+      tinypool: 1.0.2
+      tinyrainbow: 1.2.0
+      vite: 5.4.11(@types/node@20.16.0)
+      vite-node: 2.1.8(@types/node@20.16.0)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
   /vitest@2.1.8(@types/node@20.16.0)(jsdom@20.0.1):
     resolution: {integrity: sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -17294,7 +17414,3 @@ packages:
   /zod@3.23.5:
     resolution: {integrity: sha512-fkwiq0VIQTksNNA131rDOsVJcns0pfVUjHzLrNBiF/O/Xxb5lQyEXkhZWcJ7npWsYlvs+h0jFWXXy4X46Em1JA==}
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
Closes #107 , fixes #120 

Renders the checklist for each letter of the alphabet separately (with its own header and page count), then concatenates A-K and L-Z into two printable PDFs before exporting to the USB drive.