### PR TITLE
bump grace period

### DIFF
--- a/libs/printing/src/printer/printer.ts
+++ b/libs/printing/src/printer/printer.ts
@@ -20,7 +20,7 @@ const debug = rootDebug.extend('manager');
  * from the CUPS server for a period after each print. We give the printer this
  * much time to reconnect before we consider it disconnected.
  */
-const POST_PRINT_DISCONNECT_ALLOWANCE = 2000;
+const POST_PRINT_DISCONNECT_ALLOWANCE = 3000;
 
 interface PrinterDevice {
   uri?: string;


### PR DESCRIPTION
When printing about 1,000 receipts, I saw one instance of the printer blip still after #111. Upping the timeout slightly.