### PR TITLE
move dev dock handle to left to not block network indicator

### DIFF
--- a/libs/dev-dock/frontend/src/dev_dock.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.tsx
@@ -563,6 +563,7 @@ const Container = styled.div`
      * shadow */
     #handle {
       top: 60px;
+      left: -160px;
     }
   }
   /* Slide the dock down when open */
@@ -591,6 +592,7 @@ const Handle = styled.button`
   position: relative;
   /* Overlap with content so that filter shadow is not visible */
   top: -2px;
+  left: -160px;
 `;
 
 function createQueryClient() {


### PR DESCRIPTION
@jonahkagan feel free to have a better solution here but the dev dock handle is blocking the network indicator on vx dev machines right now so I'm just bumping the arrow handle to the left some to make it more out of the way 