### PR TITLE
Always increment check-in numbers, even after undo

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -149,12 +149,11 @@ function buildApi(context: AppContext) {
       voterId: string;
       identificationMethod: VoterIdentificationMethod;
     }): Promise<void> {
-      const { voter, count } = store.recordVoterCheckIn(input);
+      const { voter } = store.recordVoterCheckIn(input);
       debug('Checked in voter %s', voter.voterId);
 
       const receipt = React.createElement(CheckInReceipt, {
         voter,
-        count,
         machineId,
       });
       debug('Printing check-in receipt for voter %s', voter.voterId);

--- a/backend/src/receipts/check_in_receipt.tsx
+++ b/backend/src/receipts/check_in_receipt.tsx
@@ -12,11 +12,9 @@ import {
 
 export function CheckInReceipt({
   voter,
-  count,
   machineId,
 }: {
   voter: Voter;
-  count: number;
   machineId: string;
 }): JSX.Element {
   const { checkIn } = voter;
@@ -33,7 +31,7 @@ export function CheckInReceipt({
       >
         <div>
           <div>
-            <strong>Check-In Number: {count}</strong>
+            <strong>Check-In #{checkIn.checkInNumber}</strong>
           </div>
           {checkIn.isAbsentee && <div>Absentee</div>}
           <div>

--- a/backend/src/receipts/undo_check_in_receipt.tsx
+++ b/backend/src/receipts/undo_check_in_receipt.tsx
@@ -31,7 +31,7 @@ export function UndoCheckInReceipt({
       >
         <div>
           <div>
-            <strong>Undo Check-In</strong>
+            <strong>Undo Check-In #{checkIn.checkInNumber}</strong>
           </div>
           <div>{format.localeNumericDateAndTime(new Date())}</div>
           <div>Pollbook: {machineId}</div>
@@ -57,7 +57,7 @@ export function UndoCheckInReceipt({
       <br />
 
       <div>
-        <strong>Check-In Details</strong>
+        <strong>Check-In #{checkIn.checkInNumber} Details</strong>
       </div>
       <div>{format.localeNumericDateAndTime(new Date(checkIn.timestamp))}</div>
       <div>Pollbook: {checkIn.machineId}</div>

--- a/backend/src/store.ts
+++ b/backend/src/store.ts
@@ -507,19 +507,37 @@ export class Store {
     return this.currentClock.now();
   }
 
+  private nextCheckInNumber(): number {
+    // Count all of the check-in events that have occurred and add one. This
+    // ensures that when we undo a check-in, the next check-in will have a
+    // unique number. Note that we don't have any cross-machine locking, so it's
+    // still possible for two machines to generate the same check-in number if
+    // they have a different set of events.
+    const { checkInCount } = this.client.one(
+      `
+        SELECT COUNT(*) as checkInCount
+        FROM event_log
+        WHERE event_type = ?
+      `,
+      EventType.VoterCheckIn
+    ) as { checkInCount: number };
+    return checkInCount + 1;
+  }
+
   recordVoterCheckIn({
     voterId,
     identificationMethod,
   }: {
     voterId: string;
     identificationMethod: VoterIdentificationMethod;
-  }): { voter: Voter; count: number } {
+  }): { voter: Voter } {
     debug('Recording check-in for voter %s', voterId);
     const voters = this.getVoters();
     assert(voters);
     const voter = voters[voterId];
     const isoTimestamp = new Date().toISOString();
     voter.checkIn = {
+      checkInNumber: this.nextCheckInNumber(),
       identificationMethod,
       isAbsentee: this.getIsAbsenteeMode(),
       machineId: this.machineId,
@@ -540,7 +558,7 @@ export class Store {
         })
       );
     });
-    return { voter, count: this.getCheckInCount() };
+    return { voter };
   }
 
   recordUndoVoterCheckIn(voterId: string): Voter {

--- a/backend/src/test_helpers.ts
+++ b/backend/src/test_helpers.ts
@@ -61,6 +61,7 @@ export function createVoterCheckInEvent(
     timestamp: hlcTimestamp,
     voterId,
     checkInData: {
+      checkInNumber: localEventId,
       timestamp,
       identificationMethod: {
         type: 'photoId',

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -80,6 +80,7 @@ export type VoterIdentificationMethod =
     };
 
 export interface VoterCheckIn {
+  checkInNumber: number;
   identificationMethod: VoterIdentificationMethod;
   isAbsentee: boolean;
   timestamp: string;
@@ -87,6 +88,7 @@ export interface VoterCheckIn {
 }
 
 export const VoterCheckInSchema: z.ZodSchema<VoterCheckIn> = z.object({
+  checkInNumber: z.number(),
   identificationMethod: z.union([
     z.object({
       type: z.literal('photoId'),

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -62,9 +62,9 @@ import {
   faPrint,
   faRotate,
   faEnvelope,
+  faCircleXmark,
 } from '@fortawesome/free-solid-svg-icons';
 import {
-  faXmarkCircle,
   faPauseCircle,
   faSquare,
   faCircle,
@@ -263,7 +263,7 @@ export const Icons = {
   },
 
   Delete(props) {
-    return <FaIcon {...props} type={faXmarkCircle} />;
+    return <FaIcon {...props} type={faCircleXmark} />;
   },
 
   Disabled(props) {


### PR DESCRIPTION
Instead of using the current number of checked-in voters to determine the next check-in number, use the count of check-in events that have occurred. This ensures that check-in numbers will still increment after an undo.