### PR TITLE
Configure IPSec and Firewall rules 

### DIFF
--- a/script/avahi-autoipd.action
+++ b/script/avahi-autoipd.action
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+case "$2" in
+    BIND)
+        # $3 is the newly assigned IP from Avahi
+        echo "Avahi-autoipd assigned IP: $3"
+        /usr/local/bin/update_ipsec.sh
+        ;;
+    UNBIND)
+        echo "Avahi-autoipd removed IP: $3"
+        # If you want to handle IP removal, you could do so here
+        ;;
+    RENEW)
+        echo "Avahi-autoipd renewed IP: $3"
+        /usr/local/bin/update_ipsec.sh
+        ;;
+esac

--- a/script/avahi-autoipd.action
+++ b/script/avahi-autoipd.action
@@ -1,17 +1,89 @@
-#!/bin/bash
+#!/bin/sh
 
-case "$2" in
-    BIND)
-        # $3 is the newly assigned IP from Avahi
-        echo "Avahi-autoipd assigned IP: $3"
-        /usr/local/bin/update_ipsec.sh
-        ;;
-    UNBIND)
-        echo "Avahi-autoipd removed IP: $3"
-        # If you want to handle IP removal, you could do so here
-        ;;
-    RENEW)
-        echo "Avahi-autoipd renewed IP: $3"
-        /usr/local/bin/update_ipsec.sh
-        ;;
-esac
+# This file is part of avahi.
+#
+# avahi is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# avahi is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with avahi; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+# USA.
+
+set -e
+
+# Command line arguments:
+#   $1 event that happened:
+#          BIND:     Successfully claimed address
+#          CONFLICT: An IP address conflict happened
+#          UNBIND:   The IP address is no longer needed
+#          STOP:     The daemon is terminating
+#   $2 interface name
+#   $3 IP address
+
+PATH="$PATH:/usr/bin:/usr/sbin:/bin:/sbin"
+
+# Use a different metric for each interface, so that we can set
+# identical routes to multiple interfaces.
+
+METRIC=$((1000 + `cat "/sys/class/net/$2/ifindex" 2>/dev/null || echo 0`))
+
+if [ -x /bin/ip -o -x /sbin/ip ] ; then
+
+    # We have the Linux ip tool from the iproute package
+
+    case "$1" in
+        BIND)
+            ip addr flush dev "$2" label "$2:avahi"
+            ip addr add "$3"/16 brd 169.254.255.255 label "$2:avahi" scope link dev "$2"
+            /vx/scripts/update-ipsec.sh $3
+            ip route add default dev "$2" metric "$METRIC" scope link ||:
+            ;;
+
+        CONFLICT|UNBIND|STOP)
+            ip route del default dev "$2" metric "$METRIC" scope link ||:
+            ip addr del "$3"/16 brd 169.254.255.255 label "$2:avahi" scope link dev "$2"
+            ;;
+
+        *)
+            echo "Unknown event $1" >&2
+            exit 1
+            ;;
+    esac
+
+elif [ -x /bin/ifconfig -o -x /sbin/ifconfig ] ; then
+
+    # We have the old ifconfig tool
+
+    case "$1" in
+        BIND)
+            ifconfig "$2:avahi" inet "$3" netmask 255.255.0.0 broadcast 169.254.255.255 up
+            route add default dev "$2:avahi" metric "$METRIC" ||:
+            ;;
+
+        CONFLICT|STOP|UNBIND)
+            route del default dev "$2:avahi" metric "$METRIC" ||:
+            ifconfig "$2:avahi" down
+            ;;
+
+        *)
+            echo "Unknown event $1" >&2
+            exit 1
+            ;;
+    esac
+
+else
+
+    echo "No network configuration tool found." >&2
+    exit 1
+
+fi
+
+exit 0

--- a/script/configure-iptables.sh
+++ b/script/configure-iptables.sh
@@ -45,6 +45,11 @@ iptables -A INPUT -p tcp --sport 3002 -m conntrack --ctstate ESTABLISHED -j ACCE
 iptables -A INPUT -p icmp -j ACCEPT
 iptables -A OUTPUT -p icmp -j ACCEPT
 
+# Allow IGMP for multicast traffic
+iptables -A INPUT -p igmp -j ACCEPT
+iptables -A OUTPUT -p igmp -j ACCEPT
+
+# Log anything that is still seen for debugging purposes.
 sudo iptables -A INPUT -m limit --limit 2/min -j LOG --log-prefix "HAKUNA:INPUT " --log-level 4
 sudo iptables -A OUTPUT -m limit --limit 2/min -j LOG --log-prefix "HAKUNA:OUTPUT " --log-level 4
 sudo iptables -A FORWARD -m limit --limit 2/min -j LOG --log-prefix "HAKUNA:FORWARD " --log-level 4

--- a/script/configure-iptables.sh
+++ b/script/configure-iptables.sh
@@ -52,3 +52,11 @@ iptables -A OUTPUT -p igmp -j ACCEPT
 sudo iptables -A INPUT -m limit --limit 2/min -j LOG --log-prefix "IPTABLES:INPUT " --log-level 4
 sudo iptables -A OUTPUT -m limit --limit 2/min -j LOG --log-prefix "IPTABLES:OUTPUT " --log-level 4
 sudo iptables -A FORWARD -m limit --limit 2/min -j LOG --log-prefix "IPTABLES:FORWARD " --log-level 4
+
+
+# To persist the rules we must run 
+# sudo su
+# iptables-save > /etc/iptables/rules.v4
+# iptables-save > /etc/iptables/rules.v6
+# exit
+#

--- a/script/configure-iptables.sh
+++ b/script/configure-iptables.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Flush existing rules
+iptables -F
+iptables -X
+
+# Set default policies to DROP
+iptables -P INPUT DROP
+iptables -P OUTPUT DROP
+iptables -P FORWARD DROP
+
+# Allow all loopback traffic
+iptables -A INPUT -i lo -j ACCEPT
+iptables -A OUTPUT -o lo -j ACCEPT
+
+# Allow established and related traffic
+iptables -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+iptables -A OUTPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+
+# ----- IPsec Negotiation and Tunnel Traffic -----
+# Allow IKE (UDP 500) and NAT-T (UDP 4500)
+iptables -A INPUT -p udp --dport 500 -j ACCEPT
+iptables -A INPUT -p udp --dport 4500 -j ACCEPT
+iptables -A OUTPUT -p udp --sport 500 -j ACCEPT
+iptables -A OUTPUT -p udp --sport 4500 -j ACCEPT
+
+# Allow ESP protocol (IPsec)
+iptables -A INPUT -p esp -j ACCEPT
+iptables -A OUTPUT -p esp -j ACCEPT
+
+# ----- mDNS (Avahi) -----
+iptables -A INPUT -p udp --dport 5353 -j ACCEPT
+iptables -A OUTPUT -p udp --dport 5353 -j ACCEPT
+
+# ----- Enforce IPsec Protection for HTTP (port 3002) -----
+# Allow outgoing HTTP on port 3002 only if it is IPsec-protected
+iptables -A OUTPUT -p tcp --dport 3002 -m policy --pol ipsec --dir out -j ACCEPT
+# Allow incoming HTTP responses on port 3002 only if they are IPsec-protected
+iptables -A INPUT -p tcp --sport 3002 -m policy --pol ipsec --dir in -j ACCEPT
+
+# Allow traffic only if it is sourced/destined to the 169.254.0.0/16 subnet:
+iptables -A OUTPUT -p tcp --dport 3002 -d 169.254.0.0/16 -j ACCEPT
+iptables -A INPUT -p tcp --sport 3002 -s 169.254.0.0/16 -j ACCEPT
+
+# Log anything else that is about to be dropped
+iptables -A INPUT -p tcp --sport 3002 -j LOG --log-prefix "DROP-HTTP-IN: "
+iptables -A OUTPUT -p tcp --dport 3002 -j LOG --log-prefix "DROP-HTTP-OUT: "
+
+# Finally, drop any HTTP (port 3002) traffic that isn’t matched by the above rules
+iptables -A INPUT -p tcp --sport 3002 -j DROP
+iptables -A OUTPUT -p tcp --dport 3002 -j DROP

--- a/script/configure-iptables.sh
+++ b/script/configure-iptables.sh
@@ -30,16 +30,15 @@ iptables -A OUTPUT -p esp -j ACCEPT
 # ----- mDNS (Avahi) -----
 iptables -A INPUT -p udp --dport 5353 -j ACCEPT
 iptables -A OUTPUT -p udp --dport 5353 -j ACCEPT
-
 # ----- Enforce IPsec Protection for HTTP (port 3002) -----
-# Allow new connections and established ones to TCP port 3002 on INPUT
-iptables -A INPUT -p tcp --dport 3002 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
-# Allow established responses from TCP port 3002 on OUTPUT
-iptables -A OUTPUT -p tcp --sport 3002 -m conntrack --ctstate ESTABLISHED -j ACCEPT
+# Allow new connections and established ones to TCP port 3002 on INPUT from 169.254.0.0/16
+iptables -A INPUT -p tcp --dport 3002 -s 169.254.0.0/16 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
+# Allow established responses from TCP port 3002 on OUTPUT to 169.254.0.0/16
+iptables -A OUTPUT -p tcp --sport 3002 -d 169.254.0.0/16 -m conntrack --ctstate ESTABLISHED -j ACCEPT
 
 # If your setup also initiates connections to port 3002 (bidirectional service), you might add:
-iptables -A OUTPUT -p tcp --dport 3002 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
-iptables -A INPUT -p tcp --sport 3002 -m conntrack --ctstate ESTABLISHED -j ACCEPT
+iptables -A OUTPUT -p tcp --dport 3002 -d 169.254.0.0/16 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
+iptables -A INPUT -p tcp --sport 3002 -s 169.254.0.0/16 -m conntrack --ctstate ESTABLISHED -j ACCEPT
 
 # Allow basic pings for troubleshooting
 iptables -A INPUT -p icmp -j ACCEPT

--- a/script/configure-iptables.sh
+++ b/script/configure-iptables.sh
@@ -49,6 +49,6 @@ iptables -A INPUT -p igmp -j ACCEPT
 iptables -A OUTPUT -p igmp -j ACCEPT
 
 # Log anything that is still seen for debugging purposes.
-sudo iptables -A INPUT -m limit --limit 2/min -j LOG --log-prefix "HAKUNA:INPUT " --log-level 4
-sudo iptables -A OUTPUT -m limit --limit 2/min -j LOG --log-prefix "HAKUNA:OUTPUT " --log-level 4
-sudo iptables -A FORWARD -m limit --limit 2/min -j LOG --log-prefix "HAKUNA:FORWARD " --log-level 4
+sudo iptables -A INPUT -m limit --limit 2/min -j LOG --log-prefix "IPTABLES:INPUT " --log-level 4
+sudo iptables -A OUTPUT -m limit --limit 2/min -j LOG --log-prefix "IPTABLES:OUTPUT " --log-level 4
+sudo iptables -A FORWARD -m limit --limit 2/min -j LOG --log-prefix "IPTABLES:FORWARD " --log-level 4

--- a/script/initial_configuration.sh
+++ b/script/initial_configuration.sh
@@ -33,9 +33,6 @@ if [ -n "$MACHINE_ID" ]; then
     echo "$MACHINE_ID" | sudo tee /vx/config/machine-id > /dev/null
 fi
 
-echo "Setting up iptables firewall rules..."
-sudo bash "$SCRIPT_DIR/configure-iptables.sh"
-
 sudo udevadm control --reload-rules
 sudo systemctl daemon-reload
 sudo systemctl enable join-mesh-network

--- a/script/initial_configuration.sh
+++ b/script/initial_configuration.sh
@@ -34,18 +34,7 @@ if [ -n "$MACHINE_ID" ]; then
 fi
 
 echo "Setting up iptables firewall rules..."
-# Allow IPsec ESP traffic
-sudo iptables -A INPUT -i mesh0 -p esp -j ACCEPT
-# Allow IKE and NAT-T from IPsec subnet (UDP 500 & 4500)
-sudo iptables -A INPUT -i mesh0 -p udp --dport 500 -s 169.254.0.0/16 -j ACCEPT
-sudo iptables -A INPUT -i mesh0 -p udp --dport 4500 -s 169.254.0.0/16 -j ACCEPT
-# Allow mDNS for Avahi (UDP 5353)
-sudo iptables -A INPUT -i mesh0 -p udp --dport 5353 -j ACCEPT
-# Allow pollbook HTTP traffic on port 3002 from IPsec subnet
-sudo iptables -A INPUT -i mesh0 -p tcp --dport 3002 -s 169.254.0.0/16 -j ACCEPT
-sudo iptables -A INPUT -i mesh0 -p udp --dport 3002 -s 169.254.0.0/16 -j ACCEPT
-# Drop any other traffic coming in on mesh0
-sudo iptables -A INPUT -i mesh0 -j DROP
+sudo bash "$SCRIPT_DIR/configure-iptables.sh"
 
 sudo udevadm control --reload-rules
 sudo systemctl daemon-reload

--- a/script/initial_configuration.sh
+++ b/script/initial_configuration.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-sudo apt install avahi-daemon avahi-utils avahi-autoipd strongswan -y
+sudo apt install avahi-daemon avahi-utils avahi-autoipd strongswan iptables-persistent -y
 
 sudo cp "$SCRIPT_DIR/mesh-ipsec.conf" /etc/ipsec.conf
 sudo cp "$SCRIPT_DIR/avahi-autoipd.action" /etc/avahi/avahi-autoipd.action

--- a/script/initial_configuration.sh
+++ b/script/initial_configuration.sh
@@ -23,7 +23,7 @@ sudo cp "$SCRIPT_DIR/avahi-autoipd.service" /etc/systemd/system/.
 sudo cp "$SCRIPT_DIR/99-mesh-network.rules" /etc/udev/rules.d/.
 
 # --- New prompts for IPSec passphrase and Machine ID ---
-read -p "Enter IPSec Secret Passphrase (leave empty to keep unchanged): " IPSecSecret
+read -s -p "Enter IPSec Secret Passphrase (leave empty to keep unchanged): " IPSecSecret
 if [ -n "$IPSecSecret" ]; then
     echo ": PSK \"$IPSecSecret\"" | sudo tee /etc/ipsec.secrets > /dev/null
 fi

--- a/script/initial_configuration.sh
+++ b/script/initial_configuration.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 sudo apt install avahi-daemon avahi-utils avahi-autoipd strongswan -y
 
-sudo cp mesh-ipsec.conf /etc/ipsec.conf
-sudo cp avahi-autoipd.action /etc/avahi/avahi-autoipd.action
-sudo cp run-vxpollbook.sh /vx/scripts/.
-sudo cp update-vxpollbook.sh /vx/scripts/.
-sudo cp update-ipsec.sh /vx/scripts/.
-sudo cp run-vxpollbook.desktop /usr/share/applications/.
-sudo cp update-vxpollbook.desktop /usr/share/applications/.
+sudo cp "$SCRIPT_DIR/mesh-ipsec.conf" /etc/ipsec.conf
+sudo cp "$SCRIPT_DIR/avahi-autoipd.action" /etc/avahi/avahi-autoipd.action
+sudo cp "$SCRIPT_DIR/run-vxpollbook.sh" /vx/scripts/.
+sudo cp "$SCRIPT_DIR/update-vxpollbook.sh" /vx/scripts/.
+sudo cp "$SCRIPT_DIR/update-ipsec.sh" /vx/scripts/.
+sudo cp "$SCRIPT_DIR/run-vxpollbook.desktop" /usr/share/applications/.
+sudo cp "$SCRIPT_DIR/update-vxpollbook.desktop" /usr/share/applications/.
 gsettings set org.gnome.shell favorite-apps "['run-vxpollbook.desktop', 'update-vxpollbook.desktop', 'org.gnome.Screenshot.desktop', 'firefox-esr.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Terminal.desktop']"
 
 sudo systemctl disable NetworkManager
@@ -16,10 +17,23 @@ sudo systemctl disable firewalld
 sudo systemctl stop NetworkManager
 sudo systemctl stop firewalld
 
-sudo cp setup_basic_mesh.sh /vx/scripts/.
-sudo cp join-mesh-network.service /etc/systemd/system/.
-sudo cp avahi-autoipd.service /etc/systemd/system/.
-sudo cp 99-mesh-network.rules /etc/udev/rules.d/.
+sudo cp "$SCRIPT_DIR/setup_basic_mesh.sh" /vx/scripts/.
+sudo cp "$SCRIPT_DIR/join-mesh-network.service" /etc/systemd/system/.
+sudo cp "$SCRIPT_DIR/avahi-autoipd.service" /etc/systemd/system/.
+sudo cp "$SCRIPT_DIR/99-mesh-network.rules" /etc/udev/rules.d/.
+
+# --- New prompts for IPSec passphrase and Machine ID ---
+read -p "Enter IPSec Secret Passphrase (leave empty to keep unchanged): " IPSecSecret
+if [ -n "$IPSecSecret" ]; then
+    echo ": PSK \"$IPSecSecret\"" | sudo tee /etc/ipsec.secrets > /dev/null
+fi
+
+read -p "Enter Machine ID (leave empty to keep unchanged): " MACHINE_ID
+if [ -n "$MACHINE_ID" ]; then
+    sudo mkdir -p /vx/config
+    echo "$MACHINE_ID" | sudo tee /vx/config/machine-id > /dev/null
+fi
+# --- End of new prompts ---
 
 sudo udevadm control --reload-rules
 sudo systemctl daemon-reload

--- a/script/initial_configuration.sh
+++ b/script/initial_configuration.sh
@@ -35,6 +35,21 @@ if [ -n "$MACHINE_ID" ]; then
 fi
 # --- End of new prompts ---
 
+# --- New iptables firewall configuration ---
+echo "Setting up iptables firewall rules..."
+# Allow IPsec ESP traffic
+sudo iptables -A INPUT -i mesh0 -p esp -j ACCEPT
+# Allow IKE and NAT-T from IPsec subnet (UDP 500 & 4500)
+sudo iptables -A INPUT -i mesh0 -p udp --dport 500 -s 169.254.0.0/16 -j ACCEPT
+sudo iptables -A INPUT -i mesh0 -p udp --dport 4500 -s 169.254.0.0/16 -j ACCEPT
+# Allow mDNS for Avahi (UDP 5353)
+sudo iptables -A INPUT -i mesh0 -p udp --dport 5353 -j ACCEPT
+# Allow pollbook HTTP traffic on port 3002 from IPsec subnet
+sudo iptables -A INPUT -i mesh0 -p tcp --dport 3002 -s 169.254.0.0/16 -j ACCEPT
+sudo iptables -A INPUT -i mesh0 -p udp --dport 3002 -s 169.254.0.0/16 -j ACCEPT
+# Drop any other traffic coming in on mesh0
+sudo iptables -A INPUT -i mesh0 -j DROP
+
 sudo udevadm control --reload-rules
 sudo systemctl daemon-reload
 sudo systemctl enable join-mesh-network

--- a/script/initial_configuration.sh
+++ b/script/initial_configuration.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 
+sudo apt install avahi-daemon avahi-utils avahi-autoipd strongswan -y
+
+sudo cp mesh-ipsec.conf /etc/ipsec.conf
+sudo cp avahi-autoipd.action /etc/avahi/avahi-autoipd.action
 sudo cp run-vxpollbook.sh /vx/scripts/.
 sudo cp update-vxpollbook.sh /vx/scripts/.
+sudo cp update-ipsec.sh /vx/scripts/.
 sudo cp run-vxpollbook.desktop /usr/share/applications/.
 sudo cp update-vxpollbook.desktop /usr/share/applications/.
 gsettings set org.gnome.shell favorite-apps "['run-vxpollbook.desktop', 'update-vxpollbook.desktop', 'org.gnome.Screenshot.desktop', 'firefox-esr.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Terminal.desktop']"
 
-sudo apt install avahi-daemon avahi-utils avahi-autoipd
 sudo systemctl disable NetworkManager
 sudo systemctl disable firewalld
 sudo systemctl stop NetworkManager

--- a/script/initial_configuration.sh
+++ b/script/initial_configuration.sh
@@ -22,7 +22,6 @@ sudo cp "$SCRIPT_DIR/join-mesh-network.service" /etc/systemd/system/.
 sudo cp "$SCRIPT_DIR/avahi-autoipd.service" /etc/systemd/system/.
 sudo cp "$SCRIPT_DIR/99-mesh-network.rules" /etc/udev/rules.d/.
 
-# --- New prompts for IPSec passphrase and Machine ID ---
 read -s -p "Enter IPSec Secret Passphrase (leave empty to keep unchanged): " IPSecSecret
 if [ -n "$IPSecSecret" ]; then
     echo ": PSK \"$IPSecSecret\"" | sudo tee /etc/ipsec.secrets > /dev/null
@@ -33,9 +32,7 @@ if [ -n "$MACHINE_ID" ]; then
     sudo mkdir -p /vx/config
     echo "$MACHINE_ID" | sudo tee /vx/config/machine-id > /dev/null
 fi
-# --- End of new prompts ---
 
-# --- New iptables firewall configuration ---
 echo "Setting up iptables firewall rules..."
 # Allow IPsec ESP traffic
 sudo iptables -A INPUT -i mesh0 -p esp -j ACCEPT

--- a/script/mesh-ipsec.conf
+++ b/script/mesh-ipsec.conf
@@ -13,4 +13,4 @@ conn meshvpn
   dpddelay=30s
   ike=aes256-sha256-modp2048
   esp=aes256-sha256
-  keyingtries=@forever
+  keyingtries=5

--- a/script/mesh-ipsec.conf
+++ b/script/mesh-ipsec.conf
@@ -1,5 +1,5 @@
 config setup
-  charondebug="ike 4, knl 4, cfg 4, mgr 4, net 4, dmn 4,  mgr 4"
+  charondebug="ike 2, knl 2, cfg 2, mgr 2, net 2, dmn 2,  mgr 2"
 
 conn meshvpn
   authby=secret

--- a/script/mesh-ipsec.conf
+++ b/script/mesh-ipsec.conf
@@ -1,0 +1,15 @@
+config
+  charondebug="ike 4, knl 4, cfg 4, mgr 4, net 4, dmn 4,  mgr 4"
+
+conn meshvpn
+  type=transport
+  auto=route
+  left=0.0.0.0
+  leftsubnet=169.254.0.0/16
+  rightsubnet=169.254.0.0/16
+  right=%any
+  dpdaction-restart
+  dpddelay=30s
+  ike=aes256-sha256-modp2048
+  esp=aes256-sha256
+  keyingtries=@forever

--- a/script/mesh-ipsec.conf
+++ b/script/mesh-ipsec.conf
@@ -1,14 +1,15 @@
-config
+config setup
   charondebug="ike 4, knl 4, cfg 4, mgr 4, net 4, dmn 4,  mgr 4"
 
 conn meshvpn
+  authby=secret
   type=transport
   auto=route
   left=0.0.0.0
   leftsubnet=169.254.0.0/16
   rightsubnet=169.254.0.0/16
   right=%any
-  dpdaction-restart
+  dpdaction=restart
   dpddelay=30s
   ike=aes256-sha256-modp2048
   esp=aes256-sha256

--- a/script/update-ipsec.sh
+++ b/script/update-ipsec.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
 
-# Pull the current mesh0 IP (assuming it's IPv4)
-MESH_IP=$(ip -4 addr show mesh0 | awk '/inet / {print $2}' | cut -d/ -f1)
-
-if [[ -z "$MESH_IP" ]]; then
-    echo "No IPv4 address found on mesh0; cannot update IPsec."
+if [ -z "$1" ]; then
+    echo "No IP address provided; cannot update IPsec."
     exit 1
 fi
 
-echo "Updating IPsec config with mesh0 IP: $MESH_IP"
+MESH_IP="$1"
+echo "Updating IPsec config with new IP: $MESH_IP"
 
 # Update /etc/ipsec.conf:
 #   - Replaces the line starting with "left=" in the "meshvpn" connection

--- a/script/update-ipsec.sh
+++ b/script/update-ipsec.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Pull the current mesh0 IP (assuming it's IPv4)
+MESH_IP=$(ip -4 addr show mesh0 | awk '/inet / {print $2}' | cut -d/ -f1)
+
+if [[ -z "$MESH_IP" ]]; then
+    echo "No IPv4 address found on mesh0; cannot update IPsec."
+    exit 1
+fi
+
+echo "Updating IPsec config with mesh0 IP: $MESH_IP"
+
+# Update /etc/ipsec.conf:
+#   - Replaces the line starting with "left=" in the "meshvpn" connection
+sudo sed -i "s/^[[:space:]]*left=.*$/    left=$MESH_IP/" /etc/ipsec.conf
+
+# Restart strongSwan so it picks up the new IP
+sudo ipsec restart
+
+exit 0

--- a/script/update-vxpollbook.sh
+++ b/script/update-vxpollbook.sh
@@ -2,6 +2,10 @@
 
 echo "Restarting network and checking for connection"
 
+# --- Temporarily remove mesh0 DROP rule to allow internet access ---
+echo "Temporarily removing mesh0 firewall DROP rule..."
+sudo iptables -D INPUT -i mesh0 -j DROP || true
+
 # Turn on the network
 sudo systemctl start NetworkManager
 
@@ -48,8 +52,13 @@ fi
 pnpm install
 cd frontend && pnpm type-check
 
-# Turn off the network and renable the mesh network.
+# Turn off the network
 sudo systemctl stop NetworkManager
+
+# --- Reapply mesh0 firewall restrictions ---
+echo "Reapplying mesh0 firewall DROP rule..."
+sudo iptables -A INPUT -i mesh0 -j DROP
+
 sleep 1
 sudo systemctl start join-mesh-network
 

--- a/script/update-vxpollbook.sh
+++ b/script/update-vxpollbook.sh
@@ -2,10 +2,6 @@
 
 echo "Restarting network and checking for connection"
 
-# --- Temporarily remove mesh0 DROP rule to allow internet access ---
-echo "Temporarily removing mesh0 firewall DROP rule..."
-sudo iptables -D INPUT -i mesh0 -j DROP || true
-
 # Turn on the network
 sudo systemctl start NetworkManager
 
@@ -52,13 +48,8 @@ fi
 pnpm install
 cd frontend && pnpm type-check
 
-# Turn off the network
+# Turn off the network and renable the mesh network.
 sudo systemctl stop NetworkManager
-
-# --- Reapply mesh0 firewall restrictions ---
-echo "Reapplying mesh0 firewall DROP rule..."
-sudo iptables -A INPUT -i mesh0 -j DROP
-
 sleep 1
 sudo systemctl start join-mesh-network
 


### PR DESCRIPTION
This updates the configuration script so that ipsec is automatically configured to encrypt traffic in the 169.254 subnet which we are using to assign IP addresses in using avahi-autoipd. Tested by running on multiple laptops and seeing them still able to connect to one another while tcpdump shows encrypted traffic, sudo ipsec statusall shows an established communication channel, and another laptop, not configured with ipsec on the same mesh network is not able to connect. 

Also adds a script to configure firewall rules so that things are more locked down around that encrypted subnet. Tested manually on laptops but its a little annoying to figure out how to turn off the rules and turn them back on properly so for the purposes of VxDev usage this is not incorporated into the configuration scripts. The image creation process will ensure this is incorporated in our production images. 

An unneccesary amount of logging for both iptables and ipsec is currently stilll enabled as I assume it will be useful when getting production images working, I will pare it down later. 

The initial configuration script now asks for a passphrase which must be set identically across all machines you wish to connect. It also asks for a machine ID and sets that for convenience. 

In order to get ipsec working at least one machine on the network needs to know its current ip address. I handle this by setting the configuration to 0.0.0.0 and whenever avahi-autoipd sets a new ip address it calls a script that modifies the ipsec.conf file to update hte "left" value to the newly set IP. This feels a little hacky but was the only way I could determine to do this. 