### PR TITLE
Adds debugging and simulation script tweaks

### DIFF
--- a/backend/scripts/simulate_check_ins.ts
+++ b/backend/scripts/simulate_check_ins.ts
@@ -75,7 +75,7 @@ async function checkInAllVotersOnCurrentMachine(
       }
 
       if (slow) {
-        const delay = Math.floor(Math.random() * 4000) + 4000; // Random delay between 4 and 8 seconds
+        const delay = Math.floor(Math.random() * 20000) + 20000; // Random delay between 4 and 8 seconds
         await new Promise((resolve) => {
           setTimeout(resolve, delay);
         });

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -23,6 +23,7 @@ import {
   SummaryStatistics,
   ThroughputStat,
   VoterNameChangeRequest,
+  VoterCheckIn,
 } from './types';
 import { rootDebug } from './debug';
 import {
@@ -258,6 +259,7 @@ function buildApi(context: AppContext) {
       voterId: string;
       firstName: string;
       lastName: string;
+      checkIn?: VoterCheckIn;
     }> {
       return store.getAllVoters();
     },

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -33,7 +33,11 @@ import {
   NameChangeReceipt,
 } from './receipts';
 import { pollUsbDriveForPollbookPackage } from './pollbook_package';
-import { resetNetworkSetup, setupMachineNetworking } from './networking';
+import {
+  fetchEventsFromConnectedPollbooks,
+  resetNetworkSetup,
+  setupMachineNetworking,
+} from './networking';
 import { UndoCheckInReceipt } from './receipts/undo_check_in_receipt';
 import { renderAndPrintReceipt } from './receipts/printing';
 
@@ -291,6 +295,7 @@ export function buildApp(context: AppContext): Application {
   pollUsbDriveForPollbookPackage(context);
 
   void setupMachineNetworking(context);
+  fetchEventsFromConnectedPollbooks(context);
 
   return app;
 }

--- a/backend/src/globals.ts
+++ b/backend/src/globals.ts
@@ -31,7 +31,7 @@ export const WORKSPACE =
     ? join(__dirname, '../dev-workspace')
     : undefined);
 
-export const NETWORK_POLLING_INTERVAL = 5000;
+export const NETWORK_POLLING_INTERVAL = 100;
 export const MACHINE_DISCONNECTED_TIMEOUT = 10000;
 export const NETWORK_REQUEST_TIMEOUT = 1000;
 

--- a/backend/src/globals.ts
+++ b/backend/src/globals.ts
@@ -31,7 +31,8 @@ export const WORKSPACE =
     ? join(__dirname, '../dev-workspace')
     : undefined);
 
-export const NETWORK_POLLING_INTERVAL = 100;
+export const EVENT_POLLING_INTERVAL = 100;
+export const NETWORK_POLLING_INTERVAL = 2000;
 export const MACHINE_DISCONNECTED_TIMEOUT = 10000;
 export const NETWORK_REQUEST_TIMEOUT = 1000;
 

--- a/backend/src/networking.ts
+++ b/backend/src/networking.ts
@@ -92,6 +92,7 @@ export async function setupMachineNetworking({
       const currentElection = workspace.store.getElection();
       debug('Polling network for new machines');
       const services = await AvahiService.discoverHttpServices();
+      perfDebug('Loaded http services', Date.now() - lastTime);
       const previouslyConnected = workspace.store.getPollbookServicesByName();
       // If there are any services that were previously connected that no longer show up in avahi
       // Mark them as shut down
@@ -117,6 +118,9 @@ export async function setupMachineNetworking({
         continue;
       }
       for (const { name, host, port } of services) {
+        perfDebug('On inner for loop ', Date.now() - lastTime);
+        perfDebug('Checking service %s', name);
+        perfDebug('Checking service %s', host);
         if (name !== currentNodeServiceName && !workspace.store.getIsOnline()) {
           // do not bother trying to ping other nodes if we are not online
           continue;
@@ -190,7 +194,7 @@ export async function setupMachineNetworking({
       }
       // Clean up stale machines
       workspace.store.cleanupStalePollbookServices();
-      perfDebug('Finished polling network loop');
+      perfDebug('Finished polling network loop: ', Date.now() - lastTime);
     }
   });
 }

--- a/backend/src/networking.ts
+++ b/backend/src/networking.ts
@@ -15,7 +15,7 @@ import {
 import type { Api } from './app';
 
 const debug = rootDebug.extend('networking');
-const perfDebug = rootDebug.extend('networking:perf');
+const perfDebug = debug.extend('perf');
 
 const execPromise = promisify(exec);
 // Checks if there is any network interface 'UP'.
@@ -71,7 +71,7 @@ export function fetchEventsFromConnectedPollbooks({
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     for await (const _ of setInterval(EVENT_POLLING_INTERVAL)) {
       perfDebug(
-        'Polling network for new machines ms since last poll:',
+        'Polling network events ms since last poll:',
         Date.now() - lastTime
       );
       lastTime = Date.now();
@@ -85,8 +85,6 @@ export function fetchEventsFromConnectedPollbooks({
 
       for (const currentName of Object.keys(previouslyConnected)) {
         const currentPollbookService = previouslyConnected[currentName];
-        perfDebug('On inner for loop ', Date.now() - lastTime);
-        perfDebug('Checking service %s', currentPollbookService.machineId);
         if (
           currentPollbookService.status !== PollbookConnectionStatus.Connected
         ) {
@@ -124,7 +122,7 @@ export function fetchEventsFromConnectedPollbooks({
       }
       // Clean up stale machines
       workspace.store.cleanupStalePollbookServices();
-      perfDebug('Finished polling network loop: ', Date.now() - lastTime);
+      perfDebug('Finished polling event loop: ', Date.now() - lastTime);
     }
   });
 }
@@ -160,7 +158,6 @@ export async function setupMachineNetworking({
       const currentElection = workspace.store.getElection();
       debug('Polling network for new machines');
       const services = await AvahiService.discoverHttpServices();
-      perfDebug('Loaded http services', Date.now() - lastTime);
       const previouslyConnected = workspace.store.getPollbookServicesByName();
       // If there are any services that were previously connected that no longer show up in avahi
       // Mark them as shut down
@@ -186,8 +183,6 @@ export async function setupMachineNetworking({
         continue;
       }
       for (const { name, host, port } of services) {
-        perfDebug('On inner for loop ', Date.now() - lastTime);
-        perfDebug('Checking service %s', name);
         if (name !== currentNodeServiceName && !workspace.store.getIsOnline()) {
           // do not bother trying to ping other nodes if we are not online
           continue;

--- a/backend/src/store.ts
+++ b/backend/src/store.ts
@@ -43,6 +43,7 @@ import {
   VoterNameChangeRequest,
   VoterNameChange,
   VoterNameChangeEvent,
+  VoterCheckIn,
 } from './types';
 import { MACHINE_DISCONNECTED_TIMEOUT, NETWORK_EVENT_LIMIT } from './globals';
 import { HlcTimestamp, HybridLogicalClock } from './hybrid_logical_clock';
@@ -479,6 +480,7 @@ export class Store {
     voterId: string;
     firstName: string;
     lastName: string;
+    checkIn?: VoterCheckIn;
   }> {
     const voters = this.getVoters();
     if (!voters) {
@@ -488,6 +490,7 @@ export class Store {
       firstName: v.firstName,
       lastName: v.lastName,
       voterId: v.voterId,
+      checkIn: v.checkIn,
     }));
   }
 

--- a/backend/src/store.ts
+++ b/backend/src/store.ts
@@ -50,6 +50,7 @@ import { HlcTimestamp, HybridLogicalClock } from './hybrid_logical_clock';
 import { convertDbRowsToPollbookEvents } from './event_helpers';
 
 const debug = rootDebug.extend('store');
+const perfDebug = rootDebug.extend('store:perf');
 
 const SchemaPath = join(__dirname, '../schema.sql');
 
@@ -535,6 +536,8 @@ export class Store {
     voterId: string;
     identificationMethod: VoterIdentificationMethod;
   }): { voter: Voter; count: number } {
+    perfDebug('start check in');
+    const startTime = Date.now();
     debug('Recording check-in for voter %s', voterId);
     const voters = this.getVoters();
     assert(voters);
@@ -562,7 +565,16 @@ export class Store {
         })
       );
     });
-    return { voter, count: this.getCheckInCount() };
+
+    const result: { voter: Voter; count: number } = {
+      voter,
+      count: this.getCheckInCount(),
+    };
+    perfDebug(
+      `checked in ${voter.firstName} ${voter.middleName} ${voter.lastName}`
+    );
+    perfDebug('recordVoterCheckIn took %d ms', Date.now() - startTime);
+    return result;
   }
 
   recordUndoVoterCheckIn({

--- a/backend/src/store.ts
+++ b/backend/src/store.ts
@@ -50,7 +50,6 @@ import { HlcTimestamp, HybridLogicalClock } from './hybrid_logical_clock';
 import { convertDbRowsToPollbookEvents } from './event_helpers';
 
 const debug = rootDebug.extend('store');
-const perfDebug = rootDebug.extend('store:perf');
 
 const SchemaPath = join(__dirname, '../schema.sql');
 
@@ -536,7 +535,6 @@ export class Store {
     voterId: string;
     identificationMethod: VoterIdentificationMethod;
   }): { voter: Voter; count: number } {
-    perfDebug('start check in');
     const startTime = Date.now();
     debug('Recording check-in for voter %s', voterId);
     const voters = this.getVoters();
@@ -570,10 +568,6 @@ export class Store {
       voter,
       count: this.getCheckInCount(),
     };
-    perfDebug(
-      `checked in ${voter.firstName} ${voter.middleName} ${voter.lastName}`
-    );
-    perfDebug('recordVoterCheckIn took %d ms', Date.now() - startTime);
     return result;
   }
 

--- a/backend/src/test_helpers.ts
+++ b/backend/src/test_helpers.ts
@@ -61,6 +61,7 @@ export function createVoterCheckInEvent(
     timestamp: hlcTimestamp,
     voterId,
     checkInData: {
+      checkInNumber: 0,
       timestamp,
       identificationMethod: {
         type: 'photoId',

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -5,7 +5,6 @@ import {
   CountySchema,
   ElectionIdSchema,
   PrinterStatus,
-  Vote,
   Election as VxSuiteElection,
 } from '@votingworks/types';
 import { BatteryInfo } from '@votingworks/backend';
@@ -82,6 +81,7 @@ export type VoterIdentificationMethod =
     };
 
 export interface VoterCheckIn {
+  checkInNumber: number;
   identificationMethod: VoterIdentificationMethod;
   isAbsentee: boolean;
   timestamp: string;
@@ -89,6 +89,7 @@ export interface VoterCheckIn {
 }
 
 export const VoterCheckInSchema: z.ZodSchema<VoterCheckIn> = z.object({
+  checkInNumber: z.number(),
   identificationMethod: z.union([
     z.object({
       type: z.literal('photoId'),


### PR DESCRIPTION
Improves the simulation script and some debug logging to make testing for duplicate check in numbers easier. 

As a result of that testing splits the networking into two different polling intervals one to fetch events from connected peers and one to manage the list of connected peers. 