### PR TITLE
Receipt numbers

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -17,6 +17,7 @@ CREATE TABLE event_log (
     logical_counter INTEGER NOT NULL, -- logical time of the event
     event_type TEXT, -- e.g., "check_in", "undo_check_in"
     voter_id TEXT, -- voter_id of the voter involved in the event, if any
+    receipt_number INTEGER NOT NULL, -- printed receipt number for the event
     event_data TEXT not null, -- JSON data for additional details associated with the event (id type used for check in, etc.)
     PRIMARY KEY (event_id, machine_id)
 );

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -155,12 +155,12 @@ function buildApi(context: AppContext) {
       voterId: string;
       identificationMethod: VoterIdentificationMethod;
     }): Promise<void> {
-      const { voter, count } = store.recordVoterCheckIn(input);
+      const { voter, receiptNumber } = store.recordVoterCheckIn(input);
       debug('Checked in voter %s', voter.voterId);
 
       const receipt = React.createElement(CheckInReceipt, {
         voter,
-        count,
+        receiptNumber,
         machineId,
       });
       debug('Printing check-in receipt for voter %s', voter.voterId);
@@ -173,12 +173,13 @@ function buildApi(context: AppContext) {
     }): Promise<void> {
       // Copy voter before undoing check-in so we can print the receipt with check-in data
       const voter: Voter = { ...store.getVoter(input.voterId) };
-      store.recordUndoVoterCheckIn(input);
+      const { receiptNumber } = store.recordUndoVoterCheckIn(input);
       debug('Undid check-in for voter %s', input.voterId);
       const receipt = React.createElement(UndoCheckInReceipt, {
         voter,
-        machineId,
         reason: input.reason,
+        receiptNumber,
+        machineId,
       });
       debug('Printing check-in receipt for voter %s', voter.voterId);
       await renderAndPrintReceipt(printer, receipt);
@@ -188,12 +189,13 @@ function buildApi(context: AppContext) {
       voterId: string;
       addressChangeData: VoterAddressChangeRequest;
     }): Promise<Voter> {
-      const voter = store.changeVoterAddress(
+      const { voter, receiptNumber } = store.changeVoterAddress(
         input.voterId,
         input.addressChangeData
       );
       const receipt = React.createElement(AddressChangeReceipt, {
         voter,
+        receiptNumber,
         machineId,
       });
       debug('Printing address change receipt for voter %s', voter.voterId);
@@ -205,9 +207,13 @@ function buildApi(context: AppContext) {
       voterId: string;
       nameChangeData: VoterNameChangeRequest;
     }): Promise<Voter> {
-      const voter = store.changeVoterName(input.voterId, input.nameChangeData);
+      const { voter, receiptNumber } = store.changeVoterName(
+        input.voterId,
+        input.nameChangeData
+      );
       const receipt = React.createElement(NameChangeReceipt, {
         voter,
+        receiptNumber,
         machineId,
       });
       debug('Printing name change receipt for voter %s', voter.voterId);
@@ -218,9 +224,12 @@ function buildApi(context: AppContext) {
     async registerVoter(input: {
       registrationData: VoterRegistrationRequest;
     }): Promise<Voter> {
-      const voter = store.registerVoter(input.registrationData);
+      const { voter, receiptNumber } = store.registerVoter(
+        input.registrationData
+      );
       const receipt = React.createElement(RegistrationReceipt, {
         voter,
+        receiptNumber,
         machineId,
       });
       debug('Printing registration receipt for voter %s', voter.voterId);

--- a/backend/src/backup_worker.ts
+++ b/backend/src/backup_worker.ts
@@ -87,11 +87,13 @@ async function exportBackupVoterChecklist(
   console.time('Exported backup voter checklist');
   const voterGroups = workspace.store.groupVotersAlphabeticallyByLastName();
   const totalCheckIns = workspace.store.getCheckInCount();
+  const lastReceiptNumber = workspace.store.getNextReceiptNumber() - 1;
   const groupPdfs = iter(voterGroups)
     .async()
     .map(async (voterGroup) => {
       const headerElement = React.createElement(VoterChecklistHeader, {
         totalCheckIns,
+        lastReceiptNumber,
         voterGroup,
       });
       const tableElement = React.createElement(VoterChecklist, {

--- a/backend/src/event_helpers.ts
+++ b/backend/src/event_helpers.ts
@@ -25,6 +25,7 @@ export function convertDbRowsToPollbookEvents(
         localEventId: event.event_id,
         machineId: event.machine_id,
         voterId: event.voter_id,
+        receiptNumber: event.receipt_number,
         timestamp: {
           physical: event.physical_time,
           logical: event.logical_counter,

--- a/backend/src/receipts/address_change_receipt.tsx
+++ b/backend/src/receipts/address_change_receipt.tsx
@@ -3,6 +3,7 @@ import { assert } from '@votingworks/basics';
 import { Icons } from '@votingworks/ui';
 import {
   PartyName,
+  ReceiptNumber,
   StyledReceipt,
   VoterAddress,
   VoterName,
@@ -31,9 +32,11 @@ function AddressChange({
 
 export function AddressChangeReceipt({
   voter,
+  receiptNumber,
   machineId,
 }: {
   voter: Voter;
+  receiptNumber: number;
   machineId: string;
 }): JSX.Element {
   const { addressChange } = voter;
@@ -81,6 +84,8 @@ export function AddressChangeReceipt({
         <strong>Updated Address</strong>
         <AddressChange address={addressChange} />
       </div>
+
+      <ReceiptNumber receiptNumber={receiptNumber} />
     </StyledReceipt>
   );
 }

--- a/backend/src/receipts/check_in_receipt.tsx
+++ b/backend/src/receipts/check_in_receipt.tsx
@@ -8,15 +8,16 @@ import {
   VoterName,
   PartyName,
   IdentificationMethod,
+  ReceiptNumber,
 } from './receipt_helpers';
 
 export function CheckInReceipt({
   voter,
-  count,
+  receiptNumber,
   machineId,
 }: {
   voter: Voter;
-  count: number;
+  receiptNumber: number;
   machineId: string;
 }): JSX.Element {
   const { checkIn } = voter;
@@ -33,9 +34,12 @@ export function CheckInReceipt({
       >
         <div>
           <div>
-            <strong>Check-In Number: {count}</strong>
+            <strong>
+              {checkIn.isAbsentee
+                ? 'Absentee Voter Check-In'
+                : 'Voter Check-In'}
+            </strong>
           </div>
-          {checkIn.isAbsentee && <div>Absentee</div>}
           <div>
             {format.localeNumericDateAndTime(new Date(checkIn.timestamp))}
           </div>
@@ -62,7 +66,9 @@ export function CheckInReceipt({
       </div>
       <VoterAddress voter={voter} />
       <div>Voter ID: {voter.voterId}</div>
-      {!checkIn.isAbsentee && <IdentificationMethod checkIn={checkIn} />}
+      <IdentificationMethod checkIn={checkIn} />
+
+      <ReceiptNumber receiptNumber={receiptNumber} />
     </StyledReceipt>
   );
 }

--- a/backend/src/receipts/name_change_receipt.tsx
+++ b/backend/src/receipts/name_change_receipt.tsx
@@ -2,13 +2,20 @@ import { assert } from '@votingworks/basics';
 import { Icons } from '@votingworks/ui';
 import { format } from '@votingworks/utils';
 import { Voter } from '../types';
-import { StyledReceipt, VoterName, PartyName } from './receipt_helpers';
+import {
+  StyledReceipt,
+  VoterName,
+  PartyName,
+  ReceiptNumber,
+} from './receipt_helpers';
 
 export function NameChangeReceipt({
   voter,
+  receiptNumber,
   machineId,
 }: {
   voter: Voter;
+  receiptNumber: number;
   machineId: string;
 }): JSX.Element {
   const { nameChange } = voter;
@@ -53,6 +60,8 @@ export function NameChangeReceipt({
           <VoterName voter={{ ...voter, nameChange: undefined }} />
         </div>
       </div>
+
+      <ReceiptNumber receiptNumber={receiptNumber} />
     </StyledReceipt>
   );
 }

--- a/backend/src/receipts/receipt_helpers.tsx
+++ b/backend/src/receipts/receipt_helpers.tsx
@@ -55,6 +55,7 @@ export function IdentificationMethod({
 }: {
   checkIn: VoterCheckIn;
 }): JSX.Element | null {
+  if (checkIn.isAbsentee) return null;
   const { identificationMethod } = checkIn;
   switch (identificationMethod.type) {
     case 'default':
@@ -64,4 +65,22 @@ export function IdentificationMethod({
     default:
       throwIllegalValue(identificationMethod);
   }
+}
+
+export function ReceiptNumber({
+  receiptNumber,
+}: {
+  receiptNumber: number;
+}): JSX.Element {
+  return (
+    <div
+      style={{
+        marginTop: '1rem',
+        fontSize: '0.75rem',
+        textAlign: 'right',
+      }}
+    >
+      Receipt #{receiptNumber}
+    </div>
+  );
 }

--- a/backend/src/receipts/registration_receipt.tsx
+++ b/backend/src/receipts/registration_receipt.tsx
@@ -7,13 +7,16 @@ import {
   StyledReceipt,
   VoterName,
   PartyName,
+  ReceiptNumber,
 } from './receipt_helpers';
 
 export function RegistrationReceipt({
   voter,
+  receiptNumber,
   machineId,
 }: {
   voter: Voter;
+  receiptNumber: number;
   machineId: string;
 }): JSX.Element {
   const { registrationEvent } = voter;
@@ -55,6 +58,8 @@ export function RegistrationReceipt({
         <PartyName party={voter.party} />
       </div>
       <VoterAddress voter={voter} />
+
+      <ReceiptNumber receiptNumber={receiptNumber} />
     </StyledReceipt>
   );
 }

--- a/backend/src/receipts/undo_check_in_receipt.tsx
+++ b/backend/src/receipts/undo_check_in_receipt.tsx
@@ -8,15 +8,18 @@ import {
   VoterName,
   PartyName,
   IdentificationMethod,
+  ReceiptNumber,
 } from './receipt_helpers';
 
 export function UndoCheckInReceipt({
   voter,
   reason,
+  receiptNumber,
   machineId,
 }: {
   voter: Voter;
   reason: string;
+  receiptNumber: number;
   machineId: string;
 }): JSX.Element {
   const { checkIn } = voter;
@@ -33,7 +36,7 @@ export function UndoCheckInReceipt({
       >
         <div>
           <div>
-            <strong>Undo Check-In</strong>
+            <strong>Undo Voter Check-In</strong>
           </div>
           <div>{format.localeNumericDateAndTime(new Date())}</div>
           <div>Pollbook: {machineId}</div>
@@ -70,7 +73,9 @@ export function UndoCheckInReceipt({
       </div>
       <div>{format.localeNumericDateAndTime(new Date(checkIn.timestamp))}</div>
       <div>Pollbook: {checkIn.machineId}</div>
-      {!checkIn.isAbsentee && <IdentificationMethod checkIn={checkIn} />}
+      <IdentificationMethod checkIn={checkIn} />
+
+      <ReceiptNumber receiptNumber={receiptNumber} />
     </StyledReceipt>
   );
 }

--- a/backend/src/store.ts
+++ b/backend/src/store.ts
@@ -115,6 +115,13 @@ export class Store {
     return this.currentClock.update(remoteClock);
   }
 
+  private getNextReceiptNumber(): number {
+    const row = this.client.one(
+      'SELECT max(receipt_number) as max_receipt_number FROM event_log'
+    ) as { max_receipt_number: number };
+    return row.max_receipt_number + 1;
+  }
+
   private getNextEventId(): number {
     if (!this.nextEventId) {
       const row = this.client.one(
@@ -331,15 +338,17 @@ export class Store {
           event_id,
           machine_id,
           voter_id,
+          receipt_number,
           event_type,
           physical_time,
           logical_counter,
           event_data
-        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       `,
         pollbookEvent.localEventId,
         pollbookEvent.machineId,
         pollbookEvent.voterId,
+        pollbookEvent.receiptNumber,
         pollbookEvent.type,
         pollbookEvent.timestamp.physical,
         pollbookEvent.timestamp.logical,
@@ -531,7 +540,7 @@ export class Store {
   }: {
     voterId: string;
     identificationMethod: VoterIdentificationMethod;
-  }): { voter: Voter; count: number } {
+  }): { voter: Voter; receiptNumber: number } {
     debug('Recording check-in for voter %s', voterId);
     const voters = this.getVoters();
     assert(voters);
@@ -543,6 +552,7 @@ export class Store {
       machineId: this.machineId,
       timestamp: isoTimestamp, // human readable timestamp for paper backup
     };
+    const receiptNumber = this.getNextReceiptNumber();
     const timestamp = this.incrementClock();
     const localEventId = this.getNextEventId();
     this.client.transaction(() => {
@@ -553,12 +563,13 @@ export class Store {
           machineId: this.machineId,
           localEventId,
           voterId,
+          receiptNumber,
           timestamp,
           checkInData: voter.checkIn,
         })
       );
     });
-    return { voter, count: this.getCheckInCount() };
+    return { voter, receiptNumber };
   }
 
   recordUndoVoterCheckIn({
@@ -567,12 +578,13 @@ export class Store {
   }: {
     voterId: string;
     reason: string;
-  }): Voter {
+  }): { voter: Voter; receiptNumber: number } {
     debug('Undoing check-in for voter %s', voterId);
     const voters = this.getVoters();
     assert(voters);
     const voter = voters[voterId];
     voter.checkIn = undefined;
+    const receiptNumber = this.getNextReceiptNumber();
     const timestamp = this.incrementClock();
     const localEventId = this.getNextEventId();
     this.client.transaction(() => {
@@ -582,12 +594,13 @@ export class Store {
           machineId: this.machineId,
           voterId,
           reason,
+          receiptNumber,
           timestamp,
           localEventId,
         })
       );
     });
-    return voter;
+    return { voter, receiptNumber };
   }
 
   private createVoterFromRegistrationData(
@@ -670,7 +683,10 @@ export class Store {
     );
   }
 
-  registerVoter(voterRegistration: VoterRegistrationRequest): Voter {
+  registerVoter(voterRegistration: VoterRegistrationRequest): {
+    voter: Voter;
+    receiptNumber: number;
+  } {
     debug('Registering voter %o', voterRegistration);
     const voters = this.getVoters();
     assert(voters);
@@ -689,6 +705,7 @@ export class Store {
     };
     const newVoter = this.createVoterFromRegistrationData(registrationEvent);
     voters[newVoter.voterId] = newVoter;
+    const receiptNumber = this.getNextReceiptNumber();
     const timestamp = this.incrementClock();
     const localEventId = this.getNextEventId();
     this.client.transaction(() => {
@@ -697,13 +714,14 @@ export class Store {
           type: EventType.VoterRegistration,
           machineId: this.machineId,
           voterId: newVoter.voterId,
+          receiptNumber,
           timestamp,
           localEventId,
           registrationData: registrationEvent,
         })
       );
     });
-    return newVoter;
+    return { voter: newVoter, receiptNumber };
   }
 
   private isVoterAddressChangeValid(
@@ -721,7 +739,7 @@ export class Store {
   changeVoterAddress(
     voterId: string,
     addressChange: VoterAddressChangeRequest
-  ): Voter {
+  ): { voter: Voter; receiptNumber: number } {
     debug(`Changing address for voter ${voterId}`);
     const voters = this.getVoters();
     assert(voters);
@@ -742,6 +760,7 @@ export class Store {
     };
     voters[voterId] = updatedVoter;
 
+    const receiptNumber = this.getNextReceiptNumber();
     const timestamp = this.incrementClock();
     const localEventId = this.getNextEventId();
     this.client.transaction(() => {
@@ -750,6 +769,7 @@ export class Store {
           type: EventType.VoterAddressChange,
           machineId: this.machineId,
           voterId,
+          receiptNumber,
           timestamp,
           localEventId,
           addressChangeData,
@@ -757,14 +777,17 @@ export class Store {
       );
     });
 
-    return updatedVoter;
+    return { voter: updatedVoter, receiptNumber };
   }
 
   private isVoterNameChangeValid(nameChange: VoterNameChangeRequest): boolean {
     return nameChange.firstName.length > 0 && nameChange.lastName.length > 0;
   }
 
-  changeVoterName(voterId: string, nameChange: VoterNameChangeRequest): Voter {
+  changeVoterName(
+    voterId: string,
+    nameChange: VoterNameChangeRequest
+  ): { voter: Voter; receiptNumber: number } {
     debug(`Changing name for voter ${voterId}`);
     const voters = this.getVoters();
     assert(voters);
@@ -782,6 +805,7 @@ export class Store {
     };
     voters[voterId] = updatedVoter;
 
+    const receiptNumber = this.getNextReceiptNumber();
     const timestamp = this.incrementClock();
     const localEventId = this.getNextEventId();
     this.client.transaction(() => {
@@ -790,6 +814,7 @@ export class Store {
           type: EventType.VoterNameChange,
           machineId: this.machineId,
           voterId,
+          receiptNumber,
           timestamp,
           localEventId,
           nameChangeData,
@@ -797,7 +822,7 @@ export class Store {
       );
     });
 
-    return updatedVoter;
+    return { voter: updatedVoter, receiptNumber };
   }
 
   // Returns the valid street info. Used when registering a voter to populate address typeahead options.

--- a/backend/src/store.ts
+++ b/backend/src/store.ts
@@ -115,13 +115,6 @@ export class Store {
     return this.currentClock.update(remoteClock);
   }
 
-  private getNextReceiptNumber(): number {
-    const row = this.client.one(
-      'SELECT max(receipt_number) as max_receipt_number FROM event_log'
-    ) as { max_receipt_number: number };
-    return row.max_receipt_number + 1;
-  }
-
   private getNextEventId(): number {
     if (!this.nextEventId) {
       const row = this.client.one(
@@ -249,6 +242,13 @@ export class Store {
         }
       }
     }
+  }
+
+  getNextReceiptNumber(): number {
+    const row = this.client.one(
+      'SELECT max(receipt_number) as max_receipt_number FROM event_log'
+    ) as { max_receipt_number: number };
+    return row.max_receipt_number + 1;
   }
 
   getConfigurationStatus(): ConfigurationStatus | undefined {

--- a/backend/src/test_helpers.ts
+++ b/backend/src/test_helpers.ts
@@ -55,6 +55,7 @@ export function createVoterCheckInEvent(
 ): VoterCheckInEvent {
   const timestamp = new Date().toISOString();
   return {
+    receiptNumber: 0,
     localEventId,
     type: EventType.VoterCheckIn,
     machineId,

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -262,6 +262,7 @@ export interface PollbookEventBase {
   type: EventType;
   machineId: string;
   localEventId: number;
+  receiptNumber: number;
   timestamp: HlcTimestamp;
 }
 
@@ -400,6 +401,7 @@ export interface EventDbRow {
   event_id: number;
   machine_id: string;
   voter_id: string;
+  receipt_number: number;
   event_type: EventType;
   event_data: string;
   physical_time: number;

--- a/backend/src/voter_checklist.tsx
+++ b/backend/src/voter_checklist.tsx
@@ -51,9 +51,11 @@ const StyledVoterChecklistHeader = styled.div`
 
 export function VoterChecklistHeader({
   totalCheckIns,
+  lastReceiptNumber,
   voterGroup,
 }: {
   totalCheckIns: number;
+  lastReceiptNumber: number;
   voterGroup: VoterGroup;
 }): JSX.Element {
   const letter = voterGroup.existingVoters[0].lastName[0].toLocaleUpperCase();
@@ -76,6 +78,7 @@ export function VoterChecklistHeader({
           <span className="totalPages" />
         </div>
         <div>Total Check-ins: {totalCheckIns.toLocaleString()}</div>
+        <div>Last Receipt: #{lastReceiptNumber}</div>
       </div>
     </StyledVoterChecklistHeader>
   );

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -62,9 +62,9 @@ import {
   faPrint,
   faRotate,
   faEnvelope,
+  faXmarkCircle,
 } from '@fortawesome/free-solid-svg-icons';
 import {
-  faXmarkCircle,
   faPauseCircle,
   faSquare,
   faCircle,


### PR DESCRIPTION
Closes #172 

Adds a global receipt number to the bottom of all receipts and prints the last receipt number on the backup voter checklist.

<img width="470" alt="Screenshot 2025-02-24 at 1 08 26 PM" src="https://github.com/user-attachments/assets/8cb72663-ed06-4b3f-afb3-ec79c90c73c3" />
<img width="479" alt="Screenshot 2025-02-24 at 1 08 36 PM" src="https://github.com/user-attachments/assets/154ab3a0-42f3-41e8-868e-71ef8d2ba9e6" />
<img width="469" alt="Screenshot 2025-02-24 at 1 08 42 PM" src="https://github.com/user-attachments/assets/3f77fe2d-7a79-45be-a04c-a30c7e68f090" />
<img width="480" alt="Screenshot 2025-02-24 at 1 08 48 PM" src="https://github.com/user-attachments/assets/edb2fc7d-1737-4b9e-abae-dbedf18f4a38" />
<img width="482" alt="Screenshot 2025-02-24 at 1 08 56 PM" src="https://github.com/user-attachments/assets/1f0c9f1e-a106-4a6d-aea4-e168b07a3c84" />

<img width="866" alt="Screenshot 2025-02-24 at 1 09 11 PM" src="https://github.com/user-attachments/assets/076c89ef-1a55-4393-b226-47400282cca1" />

