### PR TITLE
Reset cached voter search after check-ins

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -181,7 +181,7 @@ export const getVoter = {
 
 async function invalidateVoterQueries(queryClient: QueryClient) {
   await queryClient.invalidateQueries(getVoter.queryKey());
-  await queryClient.invalidateQueries(searchVoters.queryKey());
+  await queryClient.resetQueries(searchVoters.queryKey());
 }
 
 export const getCheckInCounts = {


### PR DESCRIPTION
This solves the flickering that was happening when you search for a voter after checking them in (where it showed the un-checked-in status for a moment)