### PR TITLE
Add election title and date to receipt footer

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,6 +1,6 @@
 import * as grout from '@votingworks/grout';
 import express, { Application } from 'express';
-import { err, ok, Result } from '@votingworks/basics';
+import { assertDefined, err, ok, Result } from '@votingworks/basics';
 import { DEFAULT_SYSTEM_SETTINGS, PrinterStatus } from '@votingworks/types';
 import { DippedSmartCardAuthMachineState } from '@votingworks/auth';
 import React from 'react';
@@ -158,13 +158,15 @@ function buildApi(context: AppContext) {
       voterId: string;
       identificationMethod: VoterIdentificationMethod;
     }): Promise<void> {
+      const election = assertDefined(store.getElection());
       const { voter, receiptNumber } = store.recordVoterCheckIn(input);
       debug('Checked in voter %s', voter.voterId);
 
       const receipt = React.createElement(CheckInReceipt, {
         voter,
-        receiptNumber,
         machineId,
+        receiptNumber,
+        election,
       });
       debug('Printing check-in receipt for voter %s', voter.voterId);
       await renderAndPrintReceipt(printer, receipt);
@@ -174,6 +176,7 @@ function buildApi(context: AppContext) {
       voterId: string;
       reason: string;
     }): Promise<void> {
+      const election = assertDefined(store.getElection());
       // Copy voter before undoing check-in so we can print the receipt with check-in data
       const voter: Voter = { ...store.getVoter(input.voterId) };
       const { receiptNumber } = store.recordUndoVoterCheckIn(input);
@@ -181,8 +184,9 @@ function buildApi(context: AppContext) {
       const receipt = React.createElement(UndoCheckInReceipt, {
         voter,
         reason: input.reason,
-        receiptNumber,
         machineId,
+        receiptNumber,
+        election,
       });
       debug('Printing check-in receipt for voter %s', voter.voterId);
       await renderAndPrintReceipt(printer, receipt);
@@ -192,14 +196,16 @@ function buildApi(context: AppContext) {
       voterId: string;
       addressChangeData: VoterAddressChangeRequest;
     }): Promise<Voter> {
+      const election = assertDefined(store.getElection());
       const { voter, receiptNumber } = store.changeVoterAddress(
         input.voterId,
         input.addressChangeData
       );
       const receipt = React.createElement(AddressChangeReceipt, {
         voter,
-        receiptNumber,
         machineId,
+        receiptNumber,
+        election,
       });
       debug('Printing address change receipt for voter %s', voter.voterId);
       await renderAndPrintReceipt(printer, receipt);
@@ -210,14 +216,16 @@ function buildApi(context: AppContext) {
       voterId: string;
       nameChangeData: VoterNameChangeRequest;
     }): Promise<Voter> {
+      const election = assertDefined(store.getElection());
       const { voter, receiptNumber } = store.changeVoterName(
         input.voterId,
         input.nameChangeData
       );
       const receipt = React.createElement(NameChangeReceipt, {
         voter,
-        receiptNumber,
         machineId,
+        receiptNumber,
+        election,
       });
       debug('Printing name change receipt for voter %s', voter.voterId);
       await renderAndPrintReceipt(printer, receipt);
@@ -227,13 +235,15 @@ function buildApi(context: AppContext) {
     async registerVoter(input: {
       registrationData: VoterRegistrationRequest;
     }): Promise<Voter> {
+      const election = assertDefined(store.getElection());
       const { voter, receiptNumber } = store.registerVoter(
         input.registrationData
       );
       const receipt = React.createElement(RegistrationReceipt, {
         voter,
-        receiptNumber,
         machineId,
+        receiptNumber,
+        election,
       });
       debug('Printing registration receipt for voter %s', voter.voterId);
       await renderAndPrintReceipt(printer, receipt);

--- a/backend/src/receipts/address_change_receipt.tsx
+++ b/backend/src/receipts/address_change_receipt.tsx
@@ -3,7 +3,8 @@ import { assert } from '@votingworks/basics';
 import { Icons } from '@votingworks/ui';
 import {
   PartyName,
-  ReceiptNumber,
+  ReceiptMetadata,
+  ReceiptMetadataProps,
   StyledReceipt,
   VoterAddress,
   VoterName,
@@ -32,13 +33,12 @@ function AddressChange({
 
 export function AddressChangeReceipt({
   voter,
-  receiptNumber,
   machineId,
+  ...metadata
 }: {
   voter: Voter;
-  receiptNumber: number;
   machineId: string;
-}): JSX.Element {
+} & ReceiptMetadataProps): JSX.Element {
   const { addressChange } = voter;
   assert(addressChange);
 
@@ -85,7 +85,7 @@ export function AddressChangeReceipt({
         <AddressChange address={addressChange} />
       </div>
 
-      <ReceiptNumber receiptNumber={receiptNumber} />
+      <ReceiptMetadata {...metadata} />
     </StyledReceipt>
   );
 }

--- a/backend/src/receipts/check_in_receipt.tsx
+++ b/backend/src/receipts/check_in_receipt.tsx
@@ -8,18 +8,18 @@ import {
   VoterName,
   PartyName,
   IdentificationMethod,
-  ReceiptNumber,
+  ReceiptMetadataProps,
+  ReceiptMetadata,
 } from './receipt_helpers';
 
 export function CheckInReceipt({
   voter,
-  receiptNumber,
   machineId,
+  ...metadata
 }: {
   voter: Voter;
-  receiptNumber: number;
   machineId: string;
-}): JSX.Element {
+} & ReceiptMetadataProps): JSX.Element {
   const { checkIn } = voter;
   assert(checkIn);
 
@@ -68,7 +68,7 @@ export function CheckInReceipt({
       <div>Voter ID: {voter.voterId}</div>
       <IdentificationMethod checkIn={checkIn} />
 
-      <ReceiptNumber receiptNumber={receiptNumber} />
+      <ReceiptMetadata {...metadata} />
     </StyledReceipt>
   );
 }

--- a/backend/src/receipts/name_change_receipt.tsx
+++ b/backend/src/receipts/name_change_receipt.tsx
@@ -6,18 +6,18 @@ import {
   StyledReceipt,
   VoterName,
   PartyName,
-  ReceiptNumber,
+  ReceiptMetadataProps,
+  ReceiptMetadata,
 } from './receipt_helpers';
 
 export function NameChangeReceipt({
   voter,
-  receiptNumber,
   machineId,
+  ...metadata
 }: {
   voter: Voter;
-  receiptNumber: number;
   machineId: string;
-}): JSX.Element {
+} & ReceiptMetadataProps): JSX.Element {
   const { nameChange } = voter;
   assert(nameChange);
 
@@ -61,7 +61,7 @@ export function NameChangeReceipt({
         </div>
       </div>
 
-      <ReceiptNumber receiptNumber={receiptNumber} />
+      <ReceiptMetadata {...metadata} />
     </StyledReceipt>
   );
 }

--- a/backend/src/receipts/receipt_helpers.tsx
+++ b/backend/src/receipts/receipt_helpers.tsx
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 import { throwIllegalValue } from '@votingworks/basics';
-import { Voter, VoterCheckIn } from '../types';
+import { format } from '@votingworks/utils';
+import { Font } from '@votingworks/ui';
+import { Election, Voter, VoterCheckIn } from '../types';
 
 export const StyledReceipt = styled.div``;
 
@@ -67,20 +69,35 @@ export function IdentificationMethod({
   }
 }
 
-export function ReceiptNumber({
-  receiptNumber,
-}: {
+export interface ReceiptMetadataProps {
   receiptNumber: number;
-}): JSX.Element {
+  election: Election;
+}
+
+export function ReceiptMetadata({
+  receiptNumber,
+  election,
+}: ReceiptMetadataProps): JSX.Element {
   return (
     <div
       style={{
-        marginTop: '1rem',
+        display: 'flex',
+        justifyContent: 'space-between',
+        gap: '1rem',
+        marginTop: '0.5rem',
+        paddingTop: '0.25rem',
+        borderTop: '1px solid black',
         fontSize: '0.75rem',
-        textAlign: 'right',
       }}
     >
-      Receipt #{receiptNumber}
+      <div>
+        {election.title}
+        <br />
+        {format.localeLongDate(
+          election.date.toMidnightDatetimeWithSystemTimezone()
+        )}
+      </div>
+      <div>Receipt&nbsp;#{receiptNumber}</div>
     </div>
   );
 }

--- a/backend/src/receipts/registration_receipt.tsx
+++ b/backend/src/receipts/registration_receipt.tsx
@@ -1,4 +1,4 @@
-import { assert, throwIllegalValue } from '@votingworks/basics';
+import { assert } from '@votingworks/basics';
 import { format } from '@votingworks/utils';
 import { Icons } from '@votingworks/ui';
 import { Voter } from '../types';
@@ -7,18 +7,18 @@ import {
   StyledReceipt,
   VoterName,
   PartyName,
-  ReceiptNumber,
+  ReceiptMetadataProps,
+  ReceiptMetadata,
 } from './receipt_helpers';
 
 export function RegistrationReceipt({
   voter,
-  receiptNumber,
   machineId,
+  ...metadata
 }: {
   voter: Voter;
-  receiptNumber: number;
   machineId: string;
-}): JSX.Element {
+} & ReceiptMetadataProps): JSX.Element {
   const { registrationEvent } = voter;
   assert(registrationEvent);
 
@@ -59,7 +59,7 @@ export function RegistrationReceipt({
       </div>
       <VoterAddress voter={voter} />
 
-      <ReceiptNumber receiptNumber={receiptNumber} />
+      <ReceiptMetadata {...metadata} />
     </StyledReceipt>
   );
 }

--- a/backend/src/receipts/undo_check_in_receipt.tsx
+++ b/backend/src/receipts/undo_check_in_receipt.tsx
@@ -8,20 +8,20 @@ import {
   VoterName,
   PartyName,
   IdentificationMethod,
-  ReceiptNumber,
+  ReceiptMetadataProps,
+  ReceiptMetadata,
 } from './receipt_helpers';
 
 export function UndoCheckInReceipt({
   voter,
   reason,
-  receiptNumber,
   machineId,
+  ...metadata
 }: {
   voter: Voter;
   reason: string;
-  receiptNumber: number;
   machineId: string;
-}): JSX.Element {
+} & ReceiptMetadataProps): JSX.Element {
   const { checkIn } = voter;
   assert(checkIn);
 
@@ -75,7 +75,7 @@ export function UndoCheckInReceipt({
       <div>Pollbook: {checkIn.machineId}</div>
       <IdentificationMethod checkIn={checkIn} />
 
-      <ReceiptNumber receiptNumber={receiptNumber} />
+      <ReceiptMetadata {...metadata} />
     </StyledReceipt>
   );
 }

--- a/backend/src/store.ts
+++ b/backend/src/store.ts
@@ -444,14 +444,14 @@ export class Store {
   }
 
   getIsAbsenteeMode(): boolean {
-    const { isAbsenteeMode } = this.client.one(
+    const result = this.client.one(
       `
         select
           is_absentee_mode as isAbsenteeMode
         from elections
       `
-    ) as { isAbsenteeMode: SqliteBool };
-    return fromSqliteBool(isAbsenteeMode);
+    ) as { isAbsenteeMode: SqliteBool } | undefined;
+    return result ? fromSqliteBool(result.isAbsenteeMode) : false;
   }
 
   setIsAbsenteeMode(isAbsenteeMode: boolean): void {

--- a/frontend/src/election_manager_screen.tsx
+++ b/frontend/src/election_manager_screen.tsx
@@ -28,10 +28,10 @@ export function SettingsScreen(): JSX.Element | null {
   const getIsAbsenteeModeQuery = getIsAbsenteeMode.useQuery();
   const setIsAbsenteeModeMutation = setIsAbsenteeMode.useMutation();
 
+  assert(getElectionQuery.isSuccess);
   if (!getIsAbsenteeModeQuery.isSuccess) {
     return null;
   }
-  assert(getElectionQuery.isSuccess);
 
   const election = getElectionQuery.data.unsafeUnwrap();
   const isAbsenteeMode = getIsAbsenteeModeQuery.data;


### PR DESCRIPTION
Closes #175 

Note that with a shorter election title it should all fit on two lines, which is why I used this layout (to try to save vertical space as much as possible in the average case)
<img width="459" alt="Screenshot 2025-02-24 at 4 30 47 PM" src="https://github.com/user-attachments/assets/e948b97a-ae56-4fbd-87f5-73f7a0f581d8" />
