### PR TITLE
Use changed address on receipts

### DIFF
--- a/backend/src/receipts/address_change_receipt.tsx
+++ b/backend/src/receipts/address_change_receipt.tsx
@@ -10,26 +10,6 @@ import {
 } from './receipt_helpers';
 import { Voter, VoterAddressChange } from '../types';
 
-function AddressChange({
-  address,
-}: {
-  address: VoterAddressChange;
-}): JSX.Element {
-  return (
-    <div>
-      <div>
-        {address.streetNumber}
-        {address.streetSuffix} {address.streetName}{' '}
-        {address.apartmentUnitNumber}
-      </div>
-      {address.addressLine2 === '' ? null : <div>{address.addressLine2}</div>}
-      <div>
-        {address.city}, {address.state} {address.zipCode}
-      </div>
-    </div>
-  );
-}
-
 export function AddressChangeReceipt({
   voter,
   receiptNumber,
@@ -77,12 +57,12 @@ export function AddressChangeReceipt({
       <br />
       <div>
         <strong>Previous Address</strong>
-        <VoterAddress voter={voter} />
+        <VoterAddress voter={{ ...voter, addressChange: undefined }} />
       </div>
       <br />
       <div>
         <strong>Updated Address</strong>
-        <AddressChange address={addressChange} />
+        <VoterAddress voter={voter} />
       </div>
 
       <ReceiptNumber receiptNumber={receiptNumber} />

--- a/backend/src/receipts/receipt_helpers.tsx
+++ b/backend/src/receipts/receipt_helpers.tsx
@@ -21,6 +21,22 @@ export function VoterName({ voter }: { voter: Voter }): JSX.Element {
 }
 
 export function VoterAddress({ voter }: { voter: Voter }): JSX.Element {
+  if (voter.addressChange) {
+    const address = voter.addressChange;
+    return (
+      <div>
+        <div>
+          {address.streetNumber}
+          {address.streetSuffix} {address.streetName}{' '}
+          {address.apartmentUnitNumber}
+        </div>
+        {address.addressLine2 === '' ? null : <div>{address.addressLine2}</div>}
+        <div>
+          {address.city}, {address.state} {address.zipCode}
+        </div>
+      </div>
+    );
+  }
   return (
     <div>
       <div>


### PR DESCRIPTION
Closes #178 

After a voter's address is changed, use that new address on all receipts.

<img width="477" alt="Screenshot 2025-02-24 at 4 42 49 PM" src="https://github.com/user-attachments/assets/9c284724-19ab-4c09-adf2-2cfd1d2b7813" />
<img width="467" alt="Screenshot 2025-02-24 at 4 42 56 PM" src="https://github.com/user-attachments/assets/60ff205c-5d78-41df-bb93-bd88c9d562d8" />
