### PR TITLE
Use current event count as receipt number

### DIFF
--- a/backend/src/store.ts
+++ b/backend/src/store.ts
@@ -246,9 +246,9 @@ export class Store {
 
   getNextReceiptNumber(): number {
     const row = this.client.one(
-      'SELECT max(receipt_number) as max_receipt_number FROM event_log'
-    ) as { max_receipt_number: number };
-    return row.max_receipt_number + 1;
+      'SELECT count(*) as eventCount FROM event_log'
+    ) as { eventCount: number };
+    return row.eventCount + 1;
   }
 
   getConfigurationStatus(): ConfigurationStatus | undefined {


### PR DESCRIPTION
Closes #199 

If there's a duplicate receipt number (because two pollbooks produce a receipt without seeing each others' events), this will increment the receipt number by 2, skipping one receipt number.