### PR TITLE
Remove unused street info fields from type

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -319,15 +319,6 @@ export interface ValidStreetInfo {
   zip5: string;
   zip4: string;
   district: string;
-  schoolDist: string;
-  villageDist: string;
-  usCong: string;
-  execCounc: string;
-  stateSen: string;
-  stateRep: string;
-  stateRepFlot: string;
-  countyName: string;
-  countyCommDist: string;
 }
 
 export const ValidStreetInfoSchema: z.ZodSchema<ValidStreetInfo[]> = z.array(


### PR DESCRIPTION
Closes #230 

The latest street info file only has a limited number of headers, which is fine because there were a bunch of extra ones that we don't use. This removes them from the type definition just to be safe.